### PR TITLE
Move uma migrations to ct-vis/uma.

### DIFF
--- a/core/config/database.yml
+++ b/core/config/database.yml
@@ -25,7 +25,8 @@ meca: &meca
 
 uma: &uma
   <<: *pg_base
-  database: uma
+  database: ct-vis
+  schema_search_path: uma
 
 repo_base: &repo_base
   repositories:
@@ -70,6 +71,7 @@ repo_base: &repo_base
 development:
   <<: *pg_base
   database: ct-vis
+  schema_search_path: public,uma
   <<: *repo_base  
 
 # Warning: The database defined as "test" will be erased and
@@ -83,4 +85,5 @@ development:
 production:
   <<: *pg_base
   database: ct-vis
+  schema_search_path: public,uma
   <<: *repo_base

--- a/core/config/initializers/patch_schema_dumper.rb
+++ b/core/config/initializers/patch_schema_dumper.rb
@@ -1,0 +1,75 @@
+# This solution is based on the following:
+# https://gist.github.com/drnic/9d6e63802f1a7517434c25bb80f2ec09
+# https://gist.github.com/GlenCrawford/16163abab7852c1bd550547f29971c18
+
+# In old legacy the modules (hacor, uma, meca etc.) had their own databases. In
+# new legacy the engines (ivy, uma, meca etc.) used those same separate
+# databases. This allowed the tables to not suffer from name clashes and also
+# provided some isolation from the other modules/engines.
+#
+# With hindsight that isolation was not desirable.
+#
+# In ct-visualisation-app, the engines (ivy, uma, meca, etc.) use the same
+# database but separate postgresql schemas.  This prevents the table name
+# clashes whilst still allowing foreign keys to tables in different schemas.
+#
+# It may be the case that having them all in the same schema would be the
+# better solution, but that seems a little too risky of a change at the moment.
+
+# This file monkey patches active records' schema dumper to support multiple
+# schemas.  This may stop working if active record is upgraded.  If you're
+# reading this because it's stopped working, perhaps its time to reconsider
+# having separate postgresql schemas.
+
+class ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaDumper
+  # Overridden in order to call new method "schemas".
+  def dump(stream)
+    @options[:table_name_prefix] = "public."
+    header(stream)
+    extensions(stream)
+    types(stream)
+    schemas(stream)
+    tables(stream)
+    trailer(stream)
+
+    stream
+  end
+
+  private
+
+  # Adds following lines just after the extensions:
+  # * connection.execute "CREATE SCHEMA ..."
+  # * connection.schema_search_path = ...
+  def schemas(stream)
+    @connection.schema_search_path.split(",").each do |name|
+      stream.puts %(  connection.execute "CREATE SCHEMA IF NOT EXISTS #{name}")
+    end
+    stream.puts ""
+    stream.puts %(  connection.schema_search_path = #{@connection.schema_search_path.inspect})
+    stream.puts ""
+  end
+
+  # Overridden in order to build a list of tables with their schema prefix
+  # (rest of the method is the same).
+  def tables(stream)
+    table_query = <<-SQL
+          SELECT schemaname, tablename
+          FROM pg_tables
+          WHERE schemaname = ANY(current_schemas(false))
+    SQL
+
+    sorted_tables = @connection.exec_query(table_query, "SCHEMA").map do |table|
+      "#{table["schemaname"]}.#{table["tablename"]}"
+    end.sort
+
+    sorted_tables.each do |table_name|
+      table(table_name, stream) unless ignored?(table_name)
+    end
+
+    if @connection.supports_foreign_keys?
+      sorted_tables.each do |tbl|
+        foreign_keys(tbl, stream) unless ignored?(tbl)
+      end
+    end
+  end
+end

--- a/core/db/schema.rb
+++ b/core/db/schema.rb
@@ -10,10 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_06_144934) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_23_142113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  connection.execute "CREATE SCHEMA IF NOT EXISTS public"
+  connection.execute "CREATE SCHEMA IF NOT EXISTS uma"
+
+  connection.schema_search_path = "public,uma"
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -72,6 +77,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_06_144934) do
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+  end
+
+  create_table "uma.users", id: :bigint, default: -> { "nextval('users_id_seq'::regclass)" }, force: :cascade do |t|
+    t.string "login", limit: 80, null: false
+    t.string "firstname", limit: 56, null: false
+    t.string "surname", limit: 56, null: false
+    t.text "email", default: "", null: false
+    t.string "encrypted_password", limit: 128, default: "", null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.integer "sign_in_count", default: 0, null: false
+    t.text "authentication_token"
+    t.datetime "remember_created_at"
+    t.string "reset_password_token", limit: 255
+    t.datetime "reset_password_sent_at"
+    t.boolean "root", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_uma.users_on_email", unique: true
+    t.index ["login"], name: "index_uma.users_on_login", unique: true
   end
 
 end

--- a/uma/db/migrate/20230323130639_create_uma_schema.rb
+++ b/uma/db/migrate/20230323130639_create_uma_schema.rb
@@ -1,0 +1,9 @@
+class CreateUmaSchema < ActiveRecord::Migration[7.0]
+  def up
+    execute 'CREATE SCHEMA uma'
+  end
+
+  def down
+    execute 'DROP SCHEMA uma'
+  end
+end

--- a/uma/db/migrate/20230323135936_create_users_table.rb
+++ b/uma/db/migrate/20230323135936_create_users_table.rb
@@ -1,0 +1,25 @@
+class CreateUsersTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table 'uma.users' do |t|
+      t.string :login, limit: 80, null: false
+      t.string :firstname, limit: 56, null: false
+      t.string :surname, limit: 56, null: false
+      t.text :email, null: false, default: ''
+      t.string :encrypted_password, limit: 128, null: false, default: ''
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet :current_sign_in_ip
+      t.inet :last_sign_in_ip
+      t.integer :sign_in_count, null: false, default: 0
+      t.text :authentication_token
+      t.datetime :remember_created_at
+      t.string :reset_password_token, limit: 255
+      t.datetime :reset_password_sent_at
+      t.boolean :root, null: false, default: false
+
+      t.timestamps
+    end
+    add_index 'uma.users', :login, unique: true
+    add_index 'uma.users', :email, unique: true
+  end
+end

--- a/uma/db/migrate/20230323142113_seed_default_users.rb
+++ b/uma/db/migrate/20230323142113_seed_default_users.rb
@@ -1,0 +1,33 @@
+class SeedDefaultUsers < ActiveRecord::Migration[7.0]
+  module Uma
+    class User < ActiveRecord::Base
+      establish_connection :uma
+      devise :database_authenticatable
+    end
+  end
+
+  def up
+    Uma::User.create!(
+      login: 'admin',
+      firstname: 'System',
+      surname: 'Administrator',
+      email: 'admin@test.com',
+      root: true,
+      password: 'admin',
+      password_confirmation: 'admin'
+    )
+    Uma::User.create!(
+      login: 'operator',
+      firstname: 'Normal',
+      surname: 'Operator',
+      email: 'operator@test.com',
+      root: false,
+      password: 'operator',
+      password_confirmation: 'operator'
+    )
+  end
+
+  def down
+    Uma::User.destroy_all!
+  end
+end

--- a/uma/lib/uma/engine.rb
+++ b/uma/lib/uma/engine.rb
@@ -1,5 +1,13 @@
 module Uma
   class Engine < ::Rails::Engine
     isolate_namespace Uma
+
+    initializer :append_migrations do |app|
+      unless app.root.to_s.match root.to_s
+        config.paths["db/migrate"].expanded.each do |expanded_path|
+          app.config.paths["db/migrate"] << expanded_path
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The engines are to have their tables created in their own postgresql schemas.  Whether this is a good idea or not remains to be seen.  It certainly prevents table name clashes whilst migrating the various migrations from the old legacy modules to ct-vis.

The active record schema dumper has been monkey patched to support dumping multiple schemas.

The migrations for each engine reside in the engine itself.  Some configuration of the app's paths is required to have it find the migrations.

Finally, minimal migrations for the users have been added.  The users table is limited to only those columns were currently using.  Two users have been added as fixtures: admin and operator.  The integrator user has not been added, I'm not sure how that users differs from admin.