### PR TITLE
Fix issue with new metric arrival being delayed

### DIFF
--- a/core/app/javascript/mia/coffee/src/canvas/irv/IRVController.js
+++ b/core/app/javascript/mia/coffee/src/canvas/irv/IRVController.js
@@ -65,7 +65,7 @@ class IRVController extends CanvasController {
     this.NAV_HIDE_LAYOUT_UPDATE_DELAY  = 1000;
     this.EXPORT_IMAGE_URL              = '/-/api/v1/irv/racks/export_image';
     this.METRIC_POLL_EDIT_DELAY        = 2000;
-    this.METRIC_TEMPLATES_POLL_RATE     = 113000;
+    this.METRIC_TEMPLATES_POLL_RATE    = 30000;
     this.MIN_METRIC_POLL_RATE          = 600;
     this.INVALID_POLL_COLOUR           = '#f99';
     this.DEFAULT_METRIC_STAT           = 'max';

--- a/core/app/javascript/mia/coffee/src/canvas/irv/util/Configurator.js
+++ b/core/app/javascript/mia/coffee/src/canvas/irv/util/Configurator.js
@@ -91,6 +91,7 @@ class Configurator {
       IRVController.INVALID_POLL_COLOUR         = controller_config.invalidPollColour;
       IRVController.DEFAULT_METRIC_STAT         = controller_config.defaultMetricStat;
       IRVController.MODIFIED_RACK_POLL_RATE     = controller_config.modifiedRackPollRate;
+      IRVController.METRIC_TEMPLATES_POLL_RATE  = controller_config.metricTemplatesPollRate;
     }
  
     const parser_config                  = config.PARSER;

--- a/core/app/javascript/mia/javascript/util/ComboBox.js
+++ b/core/app/javascript/mia/javascript/util/ComboBox.js
@@ -372,6 +372,12 @@ const ComboBox = new Class({
             this.button.disabled = '';
 
             this.setOptions(dataArray);
+
+            if (this.optionslist && this.isVisible(this.optionslist)) {
+              // If the dropdown is displayed, update its contents.
+              this.update();
+              this.build(this.exposed_options);
+            }
         }
     },
 

--- a/ivy/app/views/ivy/irvs/_configuration.json
+++ b/ivy/app/views/ivy/irvs/_configuration.json
@@ -80,7 +80,10 @@
     "*COMMENT*"                : "Colour to apply to metric poll rate input box if value is too low or contains garbage",
     "invalidPollColour"        : "#f99",
     "defaultMetricStat"        : "max",
+    "*COMMENT*"                : "How frequently to poll for rack/device modifications.",
     "modifiedRackPollRate"     : 30000,
+    "*COMMENT*"                : "How frequently to poll for new metrics.",
+    "metricTemplatesPollRate"  : 30000,
 
 
     "*COMMENT*" : "Export CVS button settings",


### PR DESCRIPTION
The issue is multifold:

1. There is a delay in gmetad polling ct-metric-reporting-daemon for metrics.
2. There is a delay in ct-metric-processing-daemon polling gmetad for metrics.
3. There is a delay in the IRV polling ct-vis-app for metrics.
4. New metrics are not added to an open metric selection box.

This commit fixes (4) and reduces the polling delay in (3) from 113 seconds to 30 seconds.

A better fix would be to:

1. remove ganglia's (gmetad's) involvement. That is as soon as ct-metric-reporting-daemon receives a metric, it is processed by ct-metric-reporting-daemon; and
2. use server sent events, or similar, to inform the IRV that new metrics are available.