### PR TITLE
Don't ship with default operator users

### DIFF
--- a/core/db/schema.rb
+++ b/core/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_26_145248) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_141319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/uma/db/migrate/20230510141319_remove_default_operator_users.rb
+++ b/uma/db/migrate/20230510141319_remove_default_operator_users.rb
@@ -1,0 +1,54 @@
+class RemoveDefaultOperatorUsers < ActiveRecord::Migration[7.0]
+  module Ivy
+    class HwRack < ActiveRecord::Base
+      self.table_name = "racks"
+      establish_connection :ivy
+    end
+  end
+
+  module Uma
+    class User < ActiveRecord::Base
+      establish_connection :uma
+      devise :database_authenticatable
+
+      has_many :racks, class_name: 'Ivy::HwRack'
+    end
+  end
+
+  def up
+    remove_used_user(Uma::User.find_by(login: 'operator_one'))
+    remove_used_user(Uma::User.find_by(login: 'operator_two'))
+  end
+
+  def down
+    Uma::User.create!(
+      login: 'operator_one',
+      firstname: 'Operator',
+      surname: 'One',
+      email: 'operator_one@test.com',
+      root: false,
+      password: 'operator_one',
+      password_confirmation: 'operator_one'
+    )
+    Uma::User.create!(
+      login: 'operator_two',
+      firstname: 'Operator',
+      surname: 'Two',
+      email: 'operator_two@test.com',
+      root: false,
+      password: 'operator_two',
+      password_confirmation: 'operator_two'
+    )
+  end
+
+  private
+
+  def remove_used_user(u)
+    if u.racks.empty?
+      say "Removing user:#{u.id}(#{u.login} #{u.name})"
+      u.destroy!
+    else
+      say "Not removing user:#{u.id}(#{u.login} #{u.name}), they own #{u.racks.map(&:name).join(', ')}"
+    end
+  end
+end


### PR DESCRIPTION
The default operator users are removed unless they have racks.  They will only have racks if this migration is being ran as part of an upgrade to an existing installation.