### PR TITLE
Fix billing period start and end validations

### DIFF
--- a/core/spec/models/uma/user_spec.rb
+++ b/core/spec/models/uma/user_spec.rb
@@ -119,13 +119,13 @@ RSpec.describe Uma::User, type: :model do
       it 'is not valid if start later than today' do
         user.billing_period_start = Date.current + 1.month
         user.billing_period_end = Date.current + 2.months
-        expect(user).to have_error(:billing_period_start, :less_than_or_equal_to)
+        expect(user).to have_error(:billing_period_start, "must be today or earlier")
       end
 
       it 'is not valid if end earlier than today' do
         user.billing_period_start = Date.current - 1.month
         user.billing_period_end = Date.current - 2.days
-        expect(user).to have_error(:billing_period_end, :greater_than_or_equal_to)
+        expect(user).to have_error(:billing_period_end, "must be today or later")
       end
     end
   end

--- a/uma/app/models/uma/user.rb
+++ b/uma/app/models/uma/user.rb
@@ -46,10 +46,10 @@ module Uma
       allow_blank: true
     validates :billing_period_end, comparison: { greater_than: :billing_period_start },
               unless: -> { billing_period_start.blank? || billing_period_end.blank? }
-    validates :billing_period_start, comparison: { less_than_or_equal_to: Date.current },
+    validate :billing_period_start_today_or_ealier,
               if: -> { billing_period_start && billing_period_start_changed? }
-    validates :billing_period_end, comparison: { greater_than_or_equal_to: Date.current },
-              if: -> { billing_period_start && billing_period_end_changed? }
+    validate :billing_period_end_today_or_later,
+              if: -> { billing_period_end && billing_period_end_changed? }
     validate :complete_billing_period
 
     ####################################
@@ -108,6 +108,18 @@ module Uma
     def complete_billing_period
       unless !!billing_period_start == !!billing_period_end
         errors.add(:billing_period, 'must have a start date and end date, or neither')
+      end
+    end
+
+    def billing_period_start_today_or_ealier
+      if billing_period_start && billing_period_start > Date.current
+        errors.add(:billing_period_start, 'must be today or earlier')
+      end
+    end
+
+    def billing_period_end_today_or_later
+      if billing_period_end && billing_period_end < Date.current
+        errors.add(:billing_period_end, 'must be today or later')
       end
     end
   end


### PR DESCRIPTION
A user's new billing period must start today or earlier, and must end today or later. This was not working correctly, as the ruby on rails validation logic was unexpectedly setting the comparison date to the current date as of when the application first starts. This PR fixes the comparison to check each time against the current date. 