### PR TITLE
Don't include dollar sign for costs in api responses (excluding irv)

### DIFF
--- a/app/presenters/presenter.rb
+++ b/app/presenters/presenter.rb
@@ -23,7 +23,11 @@ end
 module Costed
   extend ActiveSupport::Concern
 
+  def currency_cost
+    "$#{cost}"
+  end
+
   def cost
-    "$#{'%.2f' % o.cost}"
+    '%.2f' % o.cost
   end
 end

--- a/app/views/api/v1/irv/racks/show.rabl
+++ b/app/views/api/v1/irv/racks/show.rabl
@@ -1,5 +1,6 @@
 object @rack
-attributes :id, :name, :cost
+attributes :id, :name
+attribute :currency_cost => :cost
 attributes u_height: :uHeight, status: :buildStatus
 
 child :user, root: 'owner' do
@@ -33,7 +34,7 @@ child(:chassis, root: 'Chassis') do |foo|
         id: chassis.device.id,
         name: chassis.device.name,
         buildStatus: chassis.device.status,
-        cost: chassis.device.cost
+        cost: chassis.device.currency_cost
       },
     }
   end

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -7,7 +7,7 @@ SimpleNavigation::Configuration.run do |navigation|
     if user_signed_in?
       if !current_user.root?
         user = user_presenter(current_user)
-        primary.item :user_cost, "Total cost so far this billing period: #{user.cost}", nil,
+        primary.item :user_cost, "Total cost so far this billing period: #{user.currency_cost}", nil,
                      :link_html => {:title => "Current billing period: #{user.billing_period}"},
                      align: :right
       end

--- a/spec/requests/api/v1/devices_controller_spec.rb
+++ b/spec/requests/api/v1/devices_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
       expect(parsed_device["id"]).to eq device.id
       expect(parsed_device["name"]).to eq device.name
       expect(parsed_device["metadata"]).to eq device.metadata
-      expect(parsed_device["cost"]).to eq "$#{'%.2f' % device.cost}"
+      expect(parsed_device["cost"]).to eq "#{'%.2f' % device.cost}"
       if full_template_details
         expect(parsed_device["template"]["id"]).to eq device_template.id
       else
@@ -194,7 +194,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
           expect(parsed_device["name"]).to eq valid_attributes[:device][:name]
           expect(parsed_device["metadata"]).to eq valid_attributes[:device][:metadata]
           expect(parsed_device["status"]).to eq valid_attributes[:device][:status]
-          expect(parsed_device["cost"]).to eq "$#{'%.2f' % valid_attributes[:device][:cost]}"
+          expect(parsed_device["cost"]).to eq "#{'%.2f' % valid_attributes[:device][:cost]}"
           expect(parsed_device["public_ips"]).to eq valid_attributes[:device][:public_ips]
           expect(parsed_device["private_ips"]).to eq valid_attributes[:device][:private_ips]
           expect(parsed_device["ssh_key"]).to eq valid_attributes[:device][:ssh_key]

--- a/spec/requests/api/v1/nodes_controller_spec.rb
+++ b/spec/requests/api/v1/nodes_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           expect(parsed_device["metadata"]).to eq valid_attributes[:device][:metadata]
           expect(parsed_device["status"]).to eq valid_attributes[:device][:status]
           expect(parsed_device["template"]["id"]).to eq valid_attributes[:template_id]
-          expect(parsed_device["cost"]).to eq "$#{'%.2f' % valid_attributes[:device][:cost]}"
+          expect(parsed_device["cost"]).to eq "#{'%.2f' % valid_attributes[:device][:cost]}"
           expect(parsed_device["public_ips"]).to eq valid_attributes[:device][:public_ips]
           expect(parsed_device["private_ips"]).to eq valid_attributes[:device][:private_ips]
           expect(parsed_device["ssh_key"]).to eq valid_attributes[:device][:ssh_key]

--- a/spec/requests/api/v1/racks_controller_spec.rb
+++ b/spec/requests/api/v1/racks_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Api::V1::RacksControllers", type: :request do
       expect(parsed_rack["id"]).to eq rack.id
       expect(parsed_rack["name"]).to eq rack.name
       expect(parsed_rack["u_height"]).to eq rack.u_height
-      expect(parsed_rack["cost"]).to eq "$#{'%.2f' % rack.cost}"
+      expect(parsed_rack["cost"]).to eq "#{'%.2f' % rack.cost}"
       expect(parsed_rack["creation_output"]).to eq rack.creation_output
       expect(parsed_rack["network_details"]["id"]).to eq rack.network_details["id"]
     end
@@ -230,7 +230,7 @@ RSpec.describe "Api::V1::RacksControllers", type: :request do
           expect(parsed_rack["u_height"]).to eq valid_attributes[:rack][:u_height]
           expect(parsed_rack["owner"]["id"]).to eq valid_attributes[:rack][:user_id]
           expect(parsed_rack["metadata"]).to eq valid_attributes[:rack][:metadata]
-          expect(parsed_rack["cost"]).to eq "$0.00"
+          expect(parsed_rack["cost"]).to eq "0.00"
           expect(parsed_rack["creation_output"]).to eq valid_attributes[:rack][:creation_output]
           expect(parsed_rack["network_details"]["id"]).to eq valid_attributes[:rack][:network_details][:id]
         end
@@ -320,7 +320,7 @@ RSpec.describe "Api::V1::RacksControllers", type: :request do
           expect(parsed_rack["u_height"]).to eq valid_attributes[:rack][:u_height]
           expect(parsed_rack["metadata"]).to eq valid_attributes[:rack][:metadata]
           expect(parsed_rack["status"]).to eq valid_attributes[:rack][:status]
-          expect(parsed_rack["cost"]).to eq  "$#{'%.2f' % valid_attributes[:rack][:cost]}"
+          expect(parsed_rack["cost"]).to eq  "#{'%.2f' % valid_attributes[:rack][:cost]}"
           expect(parsed_rack["creation_output"]).to eq valid_attributes[:rack][:creation_output]
           expect(parsed_rack["network_details"]["id"]).to eq valid_attributes[:rack][:network_details][:id]
         end

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Api::V1::UsersControllers", type: :request do
           result = parsed_users.first
           expect(result['id']).to eq other_user.id
           expect(result['root']).to eq false
-          expect(result['cost']).to eq '$0.00'
+          expect(result['cost']).to eq '0.00'
           expect(result['name']).to eq other_user.name
           expect(result['email']).to eq other_user.email
           expect(result.keys.include?('billing_period_start')).to eq true


### PR DESCRIPTION
Including the dollar sign in costs for users, racks and devices in api responses is causing an issue when the value is read by the openstack service. This PR therefore removes the `$` from the responses.

The dollar sign is retained for the interactive rack view api, so this is still shown to the web user.

In the future, once we know requirements/ conventions we want to follow, we will likely want to add the ability to set a user's currency.