### PR TITLE
Remove unused dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,9 +94,6 @@ gem "rabl", "~> 0.16.1"
 ###################################
 
 gem "crack", "~> 0.4.5"
-# A memcache client.
-gem "dalli", "~> 3.2"
-
 gem "good_job", "~> 3.19"
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,6 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    dalli (3.2.3)
     dartsass-rails (0.4.1)
       railties (>= 6.0.0)
     date (3.3.3)
@@ -328,7 +327,6 @@ DEPENDENCIES
   cells-erb (~> 0.1.0)
   cells-rails (~> 0.1.5)
   crack (~> 0.4.5)
-  dalli (~> 3.2)
   dartsass-rails (= 0.4.1)
   debug
   devise (~> 4.9.2)


### PR DESCRIPTION
Dalli is a memcache client library.  It should have been removed in #60 .