### PR TITLE
Fix sign in for API clients

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -317,6 +317,10 @@ Devise.setup do |config|
   config.jwt do |jwt|
     jwt.secret = Rails.application.config.jwt_secret
     jwt.request_formats = { user: [:json] }
+    jwt.dispatch_requests = [
+      ['POST', %r{^/users/sign_in(\.json)?$}],
+      ['POST', %r{^/accounts/sign_in(\.json)?$}],
+    ]
     jwt.expiration_time = 1.day
   end
 end


### PR DESCRIPTION
Recent changes to the routes for the user listing work resulted in the `/users/sign_in.json` URL no longer responding with the token in the Authorization header.  This commit fixes that issue.  The Authorization header is now present in JSON POST requests to the following URLs.

* `/users/sign_in`
* `/users/sign_in.json`
* `/accounts/sign_in`
* `/accounts/sign_in.json`