### PR TITLE
Fix issues with user sign up

### DIFF
--- a/app/utility/http_requests/faraday/job_runner.rb
+++ b/app/utility/http_requests/faraday/job_runner.rb
@@ -18,7 +18,7 @@ module HttpRequests
     # retried by adding `retry_on ::Faraday::Error, ...` to the `ActiveJob` class.
     #
     class JobRunner
-      DEFAULT_TIMEOUT = 5
+      DEFAULT_TIMEOUT = 60
 
       def initialize(cloud_service_config:, logger:nil, timeout:nil, test_stubs:nil)
         @cloud_service_config = cloud_service_config

--- a/spec/jobs/user_signup_job_spec.rb
+++ b/spec/jobs/user_signup_job_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe UserSignupJob, type: :job do
       let(:project_id) { SecureRandom.uuid }
       let(:billing_acct_id) { SecureRandom.uuid }
       let(:response_body) {
-        {user_id: cloud_user_id, project_id: project_id, billing_acct_id: billing_acct_id}
+        {user_id: cloud_user_id, project_id: project_id, billing_account_id: billing_acct_id}
           .stringify_keys
       }
 


### PR DESCRIPTION
The response from the user handler has renamed the key `billing_acct_id` to `billing_account_id`.  This commit makes the corresponding change to the response handler.

The repsonse handling has changed to allow syncing the response in two phases.  First the data relevant to the cloud environment is validated and synced (the cloud_user_id and project_id).  If that is valid, the data relevant to the billing platform is validated and synced (the billing_acct_id).  If either of them fail, the error is now logged and the job is requeued.

Also, I've increased the default timeout for making the HTTP request from 5 seconds to 60 seconds.