### PR TITLE
Fix possible amount values in credit deposit factory

### DIFF
--- a/spec/factories/credit_deposit.rb
+++ b/spec/factories/credit_deposit.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :credit_deposit, class: 'CreditDeposit' do
-    amount { rand(10) }
+    amount { rand(1..10) }
     user { create(:user, :with_openstack_details) }
   end
 


### PR DESCRIPTION
Stops the credit deposit factory from sometimes building a deposit with an amount of `0`, which is invalid.