### PR TITLE
Send billing account id in create cluster request

### DIFF
--- a/app/jobs/create_cluster_job.rb
+++ b/app/jobs/create_cluster_job.rb
@@ -72,7 +72,9 @@ class CreateClusterJob < ApplicationJob
     def body
       {
         cloud_env: cloud_env_details,
-        cluster: cluster_details
+        cluster: cluster_details,
+        billing_account_id: @user.billing_acct_id,
+        middleware_url: @cloud_service_config.user_handler_base_url,
       }
     end
 

--- a/spec/jobs/create_cluster_job_spec.rb
+++ b/spec/jobs/create_cluster_job_spec.rb
@@ -89,5 +89,15 @@ RSpec.describe CreateClusterJob, type: :job do
                                           "project_id" => user.project_id
                                         })
     end
+
+    it "contains the users billing account id" do
+      expect(user.billing_acct_id).not_to be_nil
+      expect(subject[:billing_account_id]).to eq user.billing_acct_id
+    end
+
+    it "contains the middleware url" do
+      expect(cloud_service_config.user_handler_base_url).not_to be_nil
+      expect(subject[:middleware_url]).to eq cloud_service_config.user_handler_base_url
+    end
   end
 end


### PR DESCRIPTION
The cluster builder is going to check that the user has sufficient credits and create a killbill subscription when a cluster is created. To do this it needs the user's billing account ID.