### PR TITLE
Remove unused dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,6 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 gem "importmap-rails"
-gem "turbo-rails"
-gem "stimulus-rails"
 
 # Pin dartsass-rails to 0.4.1.  Version 0.5.0 has a dependency on sass-embedded
 # that doesn't work with dependabot.  Dependabot keeps trying to change

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,17 +311,11 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.7.0-x86_64-linux)
-    stimulus-rails (1.2.2)
-      railties (>= 6.0.0)
     stringio (3.1.0)
     temple (0.10.0)
     thor (1.3.0)
     tilt (2.0.11)
     timeout (0.4.1)
-    turbo-rails (1.4.0)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -381,8 +375,6 @@ DEPENDENCIES
   simple_form (~> 5.3)
   sprockets-rails
   sqlite3
-  stimulus-rails
-  turbo-rails
   tzinfo-data
   web-console
 


### PR DESCRIPTION
Dependabot wanted to update stimulus-rails.  It turns out we're not using it, nor are we using turbop-rails.  Let's remove them.

Refs #154