### PR TITLE
Teams - key-pair management

### DIFF
--- a/app/controllers/key_pairs_controller.rb
+++ b/app/controllers/key_pairs_controller.rb
@@ -1,14 +1,15 @@
 class KeyPairsController < ApplicationController
+  before_action :set_project_id, except: :new
+
   def new
-    authorize! :create, KeyPair
     @user = current_user
+    @key_pair = KeyPair.new(user: @user)
+    authorize! :create, @key_pair
     @cloud_service_config = CloudServiceConfig.first
     if @cloud_service_config.nil?
       flash[:alert] = "Unable to create key-pairs: cloud environment config not set"
       redirect_to root_path
-      return
     end
-    @key_pair = KeyPair.new(user: @user)
   end
 
   def index
@@ -19,20 +20,18 @@ class KeyPairsController < ApplicationController
        return
     end
 
-    unless current_user.project_id
-      flash[:alert] = "Unable to check key-pairs: you do not yet have a project id. " \
-                      "This will be added automatically shortly."
+    unless @project_id
+      flash[:alert] = "Unable to check key-pairs: you must belong to a team with a project id."
       redirect_to edit_user_registration_path
       return
     end
 
-    result = GetUserKeyPairsJob.perform_now(@cloud_service_config, current_user)
+    result = GetUserKeyPairsJob.perform_now(@cloud_service_config, current_user, @project_id)
     if result.success?
       @key_pairs = result.key_pairs
     else
       flash[:alert] = "Unable to get key-pairs: #{result.error_message}"
       redirect_to edit_user_registration_path
-      return
     end
   end
 
@@ -50,14 +49,13 @@ class KeyPairsController < ApplicationController
       return
     end
 
-    unless current_user.project_id
-      flash[:alert] = "Unable to send key-pair request: you do not yet have a project id. " \
-                      "This will be added automatically shortly."
+    unless @project_id
+      flash[:alert] = "Unable to create key-pair: you must belong to a team with a project id."
       redirect_to edit_user_registration_path
       return
     end
 
-    result = CreateKeyPairJob.perform_now(@key_pair, @cloud_service_config, current_user)
+    result = CreateKeyPairJob.perform_now(@key_pair, @cloud_service_config, current_user, @project_id)
 
     if result.success?
       render action: :success
@@ -77,14 +75,13 @@ class KeyPairsController < ApplicationController
       return
     end
 
-    unless current_user.project_id
-      flash[:alert] = "Unable to send key-pair deletion request: you do not yet have a project id. " \
-                      "This will be added automatically shortly."
+    unless @project_id
+      flash[:alert] = "Unable to send key-pair deletion request: you must belong to a team with a project id."
       redirect_to edit_user_registration_path
       return
     end
 
-    result = DeleteKeyPairJob.perform_now(params[:name], @cloud_service_config, current_user)
+    result = DeleteKeyPairJob.perform_now(params[:name], @cloud_service_config, current_user, @project_id)
 
     if result.success?
       flash[:success] = "Key-pair '#{params[:name]}' deleted"
@@ -99,5 +96,11 @@ class KeyPairsController < ApplicationController
   PERMITTED_PARAMS = %w[name key_type public_key]
   def key_pair_params
     params.require(:key_pair).permit(*PERMITTED_PARAMS)
+  end
+
+  # key pairs are user (not project) specific, but membership of a project is required
+  # to view, create and delete them
+  def set_project_id
+    @project_id = current_user.teams.where.not(project_id: nil).first&.project_id
   end
 end

--- a/app/jobs/create_key_pair_job.rb
+++ b/app/jobs/create_key_pair_job.rb
@@ -3,10 +3,11 @@ require 'faraday'
 class CreateKeyPairJob < ApplicationJob
   queue_as :default
 
-  def perform(key_pair, cloud_service_config, user, **options)
+  def perform(key_pair, cloud_service_config, user, project_id, **options)
     runner = Runner.new(
       key_pair: key_pair,
       user: user,
+      project_id: project_id,
       cloud_service_config: cloud_service_config,
       logger: logger,
       **options
@@ -32,9 +33,10 @@ class CreateKeyPairJob < ApplicationJob
   end
 
   class Runner < HttpRequests::Faraday::JobRunner
-    def initialize(key_pair:, user:, **kwargs)
+    def initialize(key_pair:, user:, project_id:, **kwargs)
       @key_pair = key_pair
       @user = user
+      @project_id = project_id
       super(**kwargs)
     end
 
@@ -93,7 +95,7 @@ class CreateKeyPairJob < ApplicationJob
         auth_url: @cloud_service_config.internal_auth_url,
         user_id: @user.cloud_user_id,
         password: @user.foreign_password,
-        project_id: @user.project_id
+        project_id: @project_id
       }
     end
   end

--- a/app/jobs/delete_key_pair_job.rb
+++ b/app/jobs/delete_key_pair_job.rb
@@ -3,10 +3,11 @@ require 'faraday'
 class DeleteKeyPairJob < ApplicationJob
   queue_as :default
 
-  def perform(key_pair_name, cloud_service_config, user, **options)
+  def perform(key_pair_name, cloud_service_config, user, project_id, **options)
     runner = Runner.new(
       key_pair_name: key_pair_name,
       user: user,
+      project_id: project_id,
       cloud_service_config: cloud_service_config,
       logger: logger,
       **options
@@ -32,9 +33,10 @@ class DeleteKeyPairJob < ApplicationJob
   end
 
   class Runner < HttpRequests::Faraday::JobRunner
-    def initialize(key_pair_name:, user:, **kwargs)
+    def initialize(key_pair_name:, user:, project_id:, **kwargs)
       @key_pair_name = key_pair_name
       @user = user
+      @project_id = project_id
       super(**kwargs)
     end
 
@@ -81,7 +83,7 @@ class DeleteKeyPairJob < ApplicationJob
         auth_url: @cloud_service_config.internal_auth_url,
         user_id: @user.cloud_user_id,
         password: @user.foreign_password,
-        project_id: @user.project_id
+        project_id: @project_id
       }
     end
   end

--- a/app/jobs/get_user_key_pairs_job.rb
+++ b/app/jobs/get_user_key_pairs_job.rb
@@ -3,9 +3,10 @@ require 'faraday'
 class GetUserKeyPairsJob < ApplicationJob
   queue_as :default
 
-  def perform(cloud_service_config, user, **options)
+  def perform(cloud_service_config, user, project_id, **options)
     runner = Runner.new(
       user: user,
+      project_id: project_id,
       cloud_service_config: cloud_service_config,
       logger: logger,
       **options
@@ -33,8 +34,9 @@ class GetUserKeyPairsJob < ApplicationJob
   end
 
   class Runner < HttpRequests::Faraday::JobRunner
-    def initialize(user:, **kwargs)
+    def initialize(user:, project_id:, **kwargs)
       @user = user
+      @project_id = project_id
       super(**kwargs)
     end
 
@@ -74,7 +76,7 @@ class GetUserKeyPairsJob < ApplicationJob
           auth_url: @cloud_service_config.internal_auth_url,
           user_id: @user.cloud_user_id,
           password: @user.foreign_password,
-          project_id: @user.project_id
+          project_id: @project_id
         }
       }
     end

--- a/spec/jobs/create_key_pair_job_spec.rb
+++ b/spec/jobs/create_key_pair_job_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe CreateKeyPairJob, type: :job do
   let(:stubs) { Faraday::Adapter::Test::Stubs.new }
   let(:cloud_service_config) { create(:cloud_service_config) }
   let(:user) { create(:user, :with_openstack_account) }
+  let(:project_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
   let(:path) { "#{cloud_service_config.user_handler_base_url}/key_pairs" }
   let(:key_pair) { build(:key_pair, user: user) }
-  subject { CreateKeyPairJob::Runner.new(key_pair: key_pair, cloud_service_config: cloud_service_config, user: user) }
+  subject { CreateKeyPairJob::Runner.new(key_pair: key_pair, cloud_service_config: cloud_service_config, user: user, project_id: project_id) }
 
   describe "url" do
     before(:each) do
@@ -32,12 +33,12 @@ RSpec.describe CreateKeyPairJob, type: :job do
       end
 
       it "returns a successful result" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result).to be_success
       end
 
       it 'populates private key' do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs)
+        described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs)
         expect(key_pair.private_key).to eq "abc"
       end
     end
@@ -48,12 +49,12 @@ RSpec.describe CreateKeyPairJob, type: :job do
       end
 
       it "returns an unsuccessful result" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result).not_to be_success
       end
 
       it "returns a sensible error_message" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result.error_message).to eq "the server responded with status 404"
       end
     end
@@ -65,12 +66,12 @@ RSpec.describe CreateKeyPairJob, type: :job do
       end
 
       it "returns an unsuccessful result" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result).not_to be_success
       end
 
       it "returns a sensible error_message" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result.error_message).to eq "Key pair with that name already exists"
       end
     end
@@ -82,12 +83,12 @@ RSpec.describe CreateKeyPairJob, type: :job do
       let(:timeout) { 0.1 }
 
       it "returns an unsuccessful result" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs, timeout: timeout)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs, timeout: timeout)
         expect(result).not_to be_success
       end
 
       it "returns a sensible error_message" do
-        result = described_class.perform_now(key_pair, cloud_service_config, user, test_stubs: stubs, timeout: timeout)
+        result = described_class.perform_now(key_pair, cloud_service_config, user, project_id, test_stubs: stubs, timeout: timeout)
         expect(result.error_message).to eq "execution expired"
       end
     end
@@ -109,7 +110,7 @@ RSpec.describe CreateKeyPairJob, type: :job do
                                           "auth_url" => cloud_service_config.internal_auth_url,
                                           "user_id" => user.cloud_user_id,
                                           "password" => user.foreign_password,
-                                          "project_id" => user.project_id
+                                          "project_id" => project_id
                                         })
     end
   end

--- a/spec/jobs/delete_key_pair_job_spec.rb
+++ b/spec/jobs/delete_key_pair_job_spec.rb
@@ -4,8 +4,12 @@ RSpec.describe DeleteKeyPairJob, type: :job do
   let(:stubs) { Faraday::Adapter::Test::Stubs.new }
   let(:cloud_service_config) { create(:cloud_service_config) }
   let(:user) { create(:user, :with_openstack_account) }
+  let(:project_id) { Faker::Alphanumeric.alphanumeric(number: 10) }
   let(:path) { "#{cloud_service_config.user_handler_base_url}/key_pairs" }
-  subject { DeleteKeyPairJob::Runner.new(key_pair_name: "my_lovely_key_pair", cloud_service_config: cloud_service_config, user: user) }
+  subject do
+    DeleteKeyPairJob::Runner.new(key_pair_name: "my_lovely_key_pair", cloud_service_config: cloud_service_config,
+                                 user: user, project_id: project_id)
+  end
 
   describe "url" do
     before(:each) do
@@ -31,7 +35,7 @@ RSpec.describe DeleteKeyPairJob, type: :job do
       end
 
       it "returns a successful result" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result).to be_success
       end
     end
@@ -42,12 +46,12 @@ RSpec.describe DeleteKeyPairJob, type: :job do
       end
 
       it "returns an unsuccessful result" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result).not_to be_success
       end
 
       it "returns a sensible error_message" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result.error_message).to eq "the server responded with status 404"
       end
     end
@@ -59,12 +63,12 @@ RSpec.describe DeleteKeyPairJob, type: :job do
       end
 
       it "returns an unsuccessful result" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result).not_to be_success
       end
 
       it "returns a sensible error_message" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs)
         expect(result.error_message).to eq "Something happened"
       end
     end
@@ -76,12 +80,12 @@ RSpec.describe DeleteKeyPairJob, type: :job do
       let(:timeout) { 0.1 }
 
       it "returns an unsuccessful result" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs, timeout: timeout)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs, timeout: timeout)
         expect(result).not_to be_success
       end
 
       it "returns a sensible error_message" do
-        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, test_stubs: stubs, timeout: timeout)
+        result = described_class.perform_now("my_lovely_key_pair", cloud_service_config, user, project_id, test_stubs: stubs, timeout: timeout)
         expect(result.error_message).to eq "execution expired"
       end
     end
@@ -99,7 +103,7 @@ RSpec.describe DeleteKeyPairJob, type: :job do
                                           "auth_url" => cloud_service_config.internal_auth_url,
                                           "user_id" => user.cloud_user_id,
                                           "password" => user.foreign_password,
-                                          "project_id" => user.project_id
+                                          "project_id" => project_id
                                         })
     end
   end


### PR DESCRIPTION
In OpenStack, key-pairs are user specific. However, in order to authenticate their management (viewing, creating and deleting), the user must be part of an openstack project and the `project_id` provided.

This PR updates the key-pair logic to now look for a project id belonging to one of the user's teams, and use that for authentication. If none is found, the user is prevented from managing keypairs.

This does not require any change to the openstack service API.

**Note**: as key-pairs are user specific, they will persist after the user is removed from a project, or the project is deleted. This also means if they no longer have any teams, they will be unable to access any existing key-pairs (but they will be accessible if the user is once again assigned to a team).

Also, as key-pairs are not tied to a project, it does not matter if a different `project_id` is used to view/delete key-pairs after they have been created (e.g. if the user moves to a different team).