### PR TITLE
Fix seed network device template migration

### DIFF
--- a/db/migrate/20240216141238_seed_network_device_template.rb
+++ b/db/migrate/20240216141238_seed_network_device_template.rb
@@ -1,5 +1,7 @@
 class SeedNetworkDeviceTemplate < ActiveRecord::Migration[7.1]
   def change
+    Template.reset_column_information
+
     reversible do |dir|
 
       dir.up do


### PR DESCRIPTION
Updates the `SeedNetworkDeviceTemplate` migration so the new `tag` field (added in the prior migration) is picked up, e.g. during a fresh install.