### PR TITLE
Update paths to other concertim repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ There is a Dockerfile in this repo for building the image.
 Racks and devices can be added and removed using the rack and device API.  Once
 devices have been added, metrics can be reported for those devices using the
 [metric reporting
-daemon](https://github.com/alces-flight/concertim-metric-reporting-daemon).
+daemon](https://github.com/openflighthpc/concertim-metric-reporting-daemon).
 
 This repo contains [rack and device API example scripts](docs/api/examples).
 The metric reporting daemon repository has its own [metric API example
-scripts](https://github.com/alces-flight/concertim-metric-reporting-daemon/tree/main/docs/examples).
+scripts](https://github.com/openflighthpc/concertim-metric-reporting-daemon/tree/main/docs/examples).
 
 Once metrics have been reported they can be visualised using the interactive
 rack view which runs in a browser.
@@ -61,7 +61,7 @@ getting started with development.
 
 Concertim Visualisation App is deployed as part of the Concertim appliance
 using the [Concertim ansible
-playbook](https://github.com/alces-flight/concertim-ansible-playbook).
+playbook](https://github.com/openflighthpc/concertim-ansible-playbook).
 
 # Contributing
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,14 +2,14 @@
 
 Concertim Visualisation App (aka `ct-visualisation-app` or `ct-vis-app`) is one
 of two apps that form the Concertim UI; the other is [metric reporting
-daemon](https://github.com/alces-flight/concertim-metric-reporting-daemon).
+daemon](https://github.com/openflighthpc/concertim-metric-reporting-daemon).
 
 ## Vagrant machine
 
 Development of both apps takes place on a Vagrant virtual machine, which is
 provisioned with the use of an ansible playbook.  The vagrant file and the
 ansible playbook can be found in the
-[concertim-ansible-playbook](https://github.com/alces-flight/concertim-ansible-playbook)
+[concertim-ansible-playbook](https://github.com/openflighthpc/concertim-ansible-playbook)
 repo.
 
 That repo contains details on how to build the vagrant machine and provision it

--- a/docs/api/examples/README.md
+++ b/docs/api/examples/README.md
@@ -2,7 +2,7 @@
 
 These example scripts demonstrate usage of the rack and device API.  Example
 scripts for the metric API can be found at
-https://github.com/alces-flight/concertim-metric-reporting-daemon/tree/main/docs/examples.
+https://github.com/openflighthpc/concertim-metric-reporting-daemon/tree/main/docs/examples.
 
 For the best experience you will want to ensure that you are viewing the
 example scripts for the same release as the Concertim instance.


### PR DESCRIPTION
Updates documentation to use new paths to other concertim repos, which are now part of the openflighthpc github organisation.