### PR TITLE
Add ability to delete volumes and networks

### DIFF
--- a/app/controllers/api/v1/devices_controller.rb
+++ b/app/controllers/api/v1/devices_controller.rb
@@ -100,7 +100,7 @@ class Api::V1::DevicesController < Api::V1::ApplicationController
   end
 
   PERMITTED_PARAMS = [
-    "name", "description", "status", "cost", 
+    "name", "type", "description", "status", "cost", 
     "public_ips", "private_ips", "ssh_key", "login_user",
     "location" => %w[rack_id start_u facing]
   ] << {metadata: {}, details: {}, volume_details: {}}

--- a/app/controllers/api/v1/irv/devices_controller.rb
+++ b/app/controllers/api/v1/irv/devices_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::Irv::DevicesController < Api::V1::Irv::BaseController
       return
     end
 
-    result = RequestStatusChangeJob.perform_now(@device, "devices", action, @cloud_service_config, current_user)
+    result = RequestStatusChangeJob.perform_now(@device, @device.subtype, action, @cloud_service_config, current_user)
 
     if result.success?
       render json: { success: true }

--- a/app/controllers/api/v1/nodes_controller.rb
+++ b/app/controllers/api/v1/nodes_controller.rb
@@ -83,7 +83,7 @@ class Api::V1::NodesController < Api::V1::ApplicationController
   end
 
   PERMITTED_PARAMS = [
-    "name", "description", "status", "cost", 
+    "name", "type", "description", "status", "cost", 
     "public_ips", "private_ips", "ssh_key", "login_user",
     "location" => %w[rack_id start_u facing],
   ] << {metadata: {}, details: {}, volume_details: {}}

--- a/app/javascript/canvas/irv/view/ChassisLabel.js
+++ b/app/javascript/canvas/irv/view/ChassisLabel.js
@@ -16,6 +16,7 @@ class ChassisLabel extends NameLabel {
     ACTIVE: 'green',
     FAILED: 'red',
     SUSPENDED: "blue",
+    AVAILABLE: "blue",
   };
 
   static buildStatusImage(buildStatus) {

--- a/app/javascript/canvas/irv/view/RackSpace.js
+++ b/app/javascript/canvas/irv/view/RackSpace.js
@@ -1605,9 +1605,15 @@ class RackSpace {
       case 'focusOn':
         return this.focusOn(params[1], params[2]);
       case 'statusChangeRequest':
-        if (params[1] !== 'destroy' || confirm(`Are you sure you want to destroy ${params[4]}? This cannot be undone.`)) {
-          return this.requestStatusChange(params[1], params[2], params[3], params[4]);
+        let act = false;
+        if (!['destroy', 'detach'].includes(params[1])) {
+          act = true;
+        } else if (params[1] === 'destroy' && confirm(`Are you sure you want to destroy ${params[4]}? This cannot be undone.`)) {
+          act = true;
+        } else if (params[1] === 'detach' && confirm(`Are you sure you want to detach ${params[4]}? This may impact operation of its associated instance(s).`)) {
+          act = true;
         }
+        if (act) return this.requestStatusChange(params[1], params[2], params[3], params[4]);
       case 'reset':
         return Events.dispatchEvent(this.rackEl, 'rackSpaceReset');
       case 'clearDeselected':

--- a/app/javascript/canvas/irv/view/RackSpace.js
+++ b/app/javascript/canvas/irv/view/RackSpace.js
@@ -1608,7 +1608,7 @@ class RackSpace {
         let act = false;
         if (!['destroy', 'detach'].includes(params[1])) {
           act = true;
-        } else if (params[1] === 'destroy' && confirm(`Are you sure you want to destroy ${params[4]}? This cannot be undone.`)) {
+        } else if (params[1] === 'destroy' && confirm(`Are you sure you want to destroy ${params[4]}? This cannot be undone and may prevent the cluster performing correctly.`)) {
           act = true;
         } else if (params[1] === 'detach' && confirm(`Are you sure you want to detach ${params[4]}? This may impact operation of its associated instance(s).`)) {
           act = true;

--- a/app/models/data_source_map.rb
+++ b/app/models/data_source_map.rb
@@ -104,7 +104,7 @@ class DataSourceMap < ApplicationRecord
 
 
   def calculate_map_to_host
-    "#{device.class.name.demodulize.downcase}:#{device.id}"
+    "#{device.data_map_class_name}:#{device.id}"
   end
 
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -55,17 +55,11 @@ class Device < ApplicationRecord
   ####################################
 
   def self.valid_statuses
-    %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
+    []
   end
 
   def self.valid_status_action_mappings
-    {
-      "IN_PROGRESS" => [],
-      "FAILED" => %w(destroy),
-      "ACTIVE" => %w(destroy off suspend),
-      "STOPPED" => %w(destroy on),
-      "SUSPENDED" => %w(destroy resume)
-    }
+    {}
   end
 
   ###########################
@@ -132,10 +126,6 @@ class Device < ApplicationRecord
 
   def valid_action?(action)
     self.class.valid_status_action_mappings[status].include?(action)
-  end
-
-  def compute_device?
-    false
   end
 
   def subtype

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -42,7 +42,7 @@ class Device < ApplicationRecord
   VALID_STATUS_ACTION_MAPPINGS = {
     "IN_PROGRESS" => [],
     "FAILED" => %w(destroy),
-    "ACTIVE" => %w(destroy off suspend),
+    "ACTIVE" => %w(destroy off suspend detach),
     "STOPPED" => %w(destroy on),
     "SUSPENDED" => %w(destroy resume)
   }
@@ -129,13 +129,18 @@ class Device < ApplicationRecord
   ####################################
 
   def valid_action?(action)
-    return false unless compute_device?
+    # return false unless compute_device? || action ==  "destroy"
 
     VALID_STATUS_ACTION_MAPPINGS[status].include?(action)
   end
 
   def compute_device?
     self.details_type == "Device::ComputeDetails"
+  end
+
+  # This suggests we probably do/will need subclasses
+  def subtype
+    self.details_type == "Device::ComputeDetails" ? "instances" : self.details_type[/::(\w+)Details/, 1].downcase << "s"
   end
 
   def openstack_id

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -81,14 +81,13 @@ class Device < ApplicationRecord
               with: /\A[a-zA-Z0-9\-\.]*\Z/,
               message: "can contain only alphanumeric characters, dots and hyphens."
             }
-  validates :status,
-            presence: true,
-            inclusion: { in: valid_statuses, message: "must be one of #{valid_statuses.to_sentence(last_word_connector: ' or ')}" }
+  validates :status, presence: true
+  validate :status_validator
   validates :cost,
             numericality: { greater_than_or_equal_to: 0 },
             allow_blank: true
   validates :details, presence: :true
-  # validate :name_validator
+  validate :name_validator
   validate :device_limit, if: :new_record?
   validate :metadata_format
   validate :details_type_not_changed
@@ -183,6 +182,14 @@ class Device < ApplicationRecord
 
     if taken_names.include?(name)
       errors.add(:name, :taken)
+    end
+  end
+
+  def status_validator
+    return unless self.status
+
+    unless self.class.valid_statuses.include?(self.status)
+      errors.add(:status, "must be one of #{self.class.valid_statuses.to_sentence(last_word_connector: ' or ')}")
     end
   end
 

--- a/app/models/device/compute_details.rb
+++ b/app/models/device/compute_details.rb
@@ -26,4 +26,16 @@
 #==============================================================================
 
 class Device::ComputeDetails < Device::Details
+
+  validate :device_is_instance
+
+  private
+
+  def device_is_instance
+    reload_device
+    return unless device.present?
+    unless device.type == "Instance"
+      self.errors.add(:device, 'must be an Instance')
+    end
+  end
 end

--- a/app/models/device/network_details.rb
+++ b/app/models/device/network_details.rb
@@ -27,15 +27,15 @@
 
 class Device::NetworkDetails < Device::Details
 
-  validate :device_uses_network_template
+  validate :device_is_network
 
   private
 
-  def device_uses_network_template
+  def device_is_network
     reload_device
     return unless device.present?
-    unless device.template.tag == 'network'
-      self.errors.add(:device, 'must use the `network` template if it has a Device::NetworkDetails')
+    unless device.type == "Network"
+      self.errors.add(:device, 'must be a Network')
     end
   end
 

--- a/app/models/device/volume_details.rb
+++ b/app/models/device/volume_details.rb
@@ -27,15 +27,15 @@
 
 class Device::VolumeDetails < Device::Details
 
-  validate :device_uses_volume_template
+  validate :device_is_volume
 
   private
 
-  def device_uses_volume_template
+  def device_is_volume
     reload_device
     return unless device.present?
-    unless device.template.tag == 'volume'
-      self.errors.add(:device, 'must use the `volume` template if it has a Device::VolumeDetails')
+    unless device.type == "Volume"
+      self.errors.add(:device, 'must be a Volume')
     end
   end
 

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
 class Instance < Device
   ####################################
   #

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -54,12 +54,20 @@ class Instance < Device
   ####################################
 
   validate :has_compute_details
+  validate :has_suitable_template
 
   private
 
   def has_compute_details
     unless details_type == 'Device::ComputeDetails'
       self.errors.add(:details_type, 'must have compute details')
+    end
+  end
+
+  def has_suitable_template
+    # Tag is used to identify unique templates, i.e. network or volume
+    unless template && template.tag == nil
+      self.errors.add(:template, 'must use an instance template')
     end
   end
 end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -1,9 +1,32 @@
 class Instance < Device
-  validate :has_compute_details
+  ####################################
+  #
+  # Class Methods
+  #
+  ####################################
 
-  def compute_device?
-    true
+  def self.valid_statuses
+    %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
   end
+
+  def self.valid_status_action_mappings
+    {
+      "IN_PROGRESS" => [],
+      "FAILED" => %w(destroy),
+      "ACTIVE" => %w(destroy off suspend),
+      "STOPPED" => %w(destroy on),
+      "SUSPENDED" => %w(destroy resume)
+    }
+  end
+
+
+  ####################################
+  #
+  # Validations
+  #
+  ####################################
+
+  validate :has_compute_details
 
   private
 

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -1,0 +1,15 @@
+class Instance < Device
+  validate :has_compute_details
+
+  def compute_device?
+    true
+  end
+
+  private
+
+  def has_compute_details
+    unless details_type == 'Device::ComputeDetails'
+      self.errors.add(:details_type, 'must have compute details')
+    end
+  end
+end

--- a/app/models/interactive_rack_view.rb
+++ b/app/models/interactive_rack_view.rb
@@ -165,7 +165,7 @@ SELECT
                                                                                                               D.name AS "name",
                                                                                                               D.status AS "buildStatus",
                                                                                                               cast(D.cost as money) AS "cost",
-                                                                                                              D.details_type AS "type"
+                                                                                                              D.type AS "type"
                                                                                                             )
                                                                                            ))
                                                                                 FROM devices D WHERE D.id = S.id

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,0 +1,31 @@
+class Network < Device
+  validate :has_network_details
+  validate :has_network_template
+
+  #############################
+  #
+  # CONSTANTS
+  #
+  ############################
+
+  VALID_STATUS_ACTION_MAPPINGS = {
+    "IN_PROGRESS" => [],
+    "FAILED" => [],
+    "ACTIVE" => [],
+    "STOPPED" => [],
+    "SUSPENDED" => []  }
+
+  private
+
+  def has_network_details
+    unless details_type == 'Device::NetworkDetails'
+      self.errors.add(:details_type, 'must have network details')
+    end
+  end
+
+  def has_network_template
+    unless device.template.tag == 'volume'
+      self.errors.add(:template, 'must use the network template')
+    end
+  end
+end

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -65,7 +65,7 @@ class Network < Device
   end
 
   def has_network_template
-    unless self.template.tag == 'network'
+    unless self.template&.tag == 'network'
       self.errors.add(:template, 'must use the network template')
     end
   end

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
 class Network < Device
 
   ####################################

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -7,16 +7,15 @@ class Network < Device
   ####################################
 
   def self.valid_statuses
-    %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
+    %w(IN_PROGRESS FAILED ACTIVE STOPPED)
   end
 
   def self.valid_status_action_mappings
     {
       "IN_PROGRESS" => [],
-      "FAILED" => [],
-      "ACTIVE" => [],
-      "STOPPED" => [],
-      "SUSPENDED" => []
+      "FAILED" => %w(destroy),
+      "ACTIVE" => %w(destroy),
+      "STOPPED" => %w(destroy)
     }
   end
 

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,19 +1,34 @@
 class Network < Device
+
+  ####################################
+  #
+  # Class Methods
+  #
+  ####################################
+
+  def self.valid_statuses
+    %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
+  end
+
+  def self.valid_status_action_mappings
+    {
+      "IN_PROGRESS" => [],
+      "FAILED" => [],
+      "ACTIVE" => [],
+      "STOPPED" => [],
+      "SUSPENDED" => []
+    }
+  end
+
+
+  ####################################
+  #
+  # Validations
+  #
+  ####################################
+
   validate :has_network_details
   validate :has_network_template
-
-  #############################
-  #
-  # CONSTANTS
-  #
-  ############################
-
-  VALID_STATUS_ACTION_MAPPINGS = {
-    "IN_PROGRESS" => [],
-    "FAILED" => [],
-    "ACTIVE" => [],
-    "STOPPED" => [],
-    "SUSPENDED" => []  }
 
   private
 

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -24,7 +24,7 @@ class Network < Device
   end
 
   def has_network_template
-    unless device.template.tag == 'volume'
+    unless self.template.tag == 'network'
       self.errors.add(:template, 'must use the network template')
     end
   end

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
 class Volume < Device
 
   ####################################

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,0 +1,33 @@
+class Volume < Device
+  validate :has_volume_details
+  validate :has_volume_template
+
+  #############################
+  #
+  # CONSTANTS
+  #
+  ############################
+
+  VALID_STATUSES = %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
+  VALID_STATUS_ACTION_MAPPINGS = {
+    "IN_PROGRESS" => [],
+    "FAILED" => %w(destroy),
+    "ACTIVE" => %w(detach),
+    "STOPPED" => %w(destroy),
+    "SUSPENDED" => %w(destroy)
+  }
+
+  private
+
+  def has_volume_details
+    unless details_type == 'Device::VolumeDetails'
+      self.errors.add(:details_type, 'must have volume details')
+    end
+  end
+
+  def has_volume_template
+    unless device.template.tag == 'volume'
+      self.errors.add(:template, 'must use the volume template')
+    end
+  end
+end

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -1,21 +1,33 @@
 class Volume < Device
+
+  ####################################
+  #
+  # Class Methods
+  #
+  ####################################
+
+  def self.valid_statuses
+    %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
+  end
+
+  def self.valid_status_action_mappings
+    {
+      "IN_PROGRESS" => [],
+      "FAILED" => %w(destroy),
+      "ACTIVE" => %w(detach),
+      "STOPPED" => %w(destroy),
+      "SUSPENDED" => %w(destroy)
+    }
+  end
+
+  ####################################
+  #
+  # Validations
+  #
+  ####################################
+
   validate :has_volume_details
   validate :has_volume_template
-
-  #############################
-  #
-  # CONSTANTS
-  #
-  ############################
-
-  VALID_STATUSES = %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
-  VALID_STATUS_ACTION_MAPPINGS = {
-    "IN_PROGRESS" => [],
-    "FAILED" => %w(destroy),
-    "ACTIVE" => %w(detach),
-    "STOPPED" => %w(destroy),
-    "SUSPENDED" => %w(destroy)
-  }
 
   private
 

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -26,7 +26,7 @@ class Volume < Device
   end
 
   def has_volume_template
-    unless device.template.tag == 'volume'
+    unless self.template.tag == 'volume'
       self.errors.add(:template, 'must use the volume template')
     end
   end

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -7,7 +7,7 @@ class Volume < Device
   ####################################
 
   def self.valid_statuses
-    %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED)
+    %w(IN_PROGRESS FAILED ACTIVE AVAILABLE)
   end
 
   def self.valid_status_action_mappings
@@ -15,8 +15,7 @@ class Volume < Device
       "IN_PROGRESS" => [],
       "FAILED" => %w(destroy),
       "ACTIVE" => %w(detach),
-      "STOPPED" => %w(destroy),
-      "SUSPENDED" => %w(destroy)
+      "AVAILABLE" => %w(destroy)
     }
   end
 

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -64,7 +64,7 @@ class Volume < Device
   end
 
   def has_volume_template
-    unless self.template.tag == 'volume'
+    unless self.template&.tag == 'volume'
       self.errors.add(:template, 'must use the volume template')
     end
   end

--- a/app/presenters/api/v1/device_presenter.rb
+++ b/app/presenters/api/v1/device_presenter.rb
@@ -38,7 +38,7 @@ module Api::V1
     include Costed
 
     # Be selective about what attributes and methods we expose.
-    delegate :id, :name, :description, :metadata, :status, :details, :details_type, to: :o
+    delegate :id, :name, :description, :metadata, :status, :details, :type, to: :o
 
     # location returns the location of the device.  For devices in simple
     # chassis, the chassis's location is returned. Devices in complex chassis,

--- a/app/presenters/device_presenter.rb
+++ b/app/presenters/device_presenter.rb
@@ -35,14 +35,11 @@ class DevicePresenter < Presenter
   include Costed
 
   delegate :name, :description, :status, :metadata,
-    :attributes,
+    :attributes, :type,
     to: :o
 
   delegate :name, :description,
     to: :template, prefix: :template
-
-  delegate :vcpus, :ram, :disk,
-    to: :template
 
   delegate :additional_details, to: :details
 

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -1,0 +1,5 @@
+class InstancePresenter < DevicePresenter
+  delegate :vcpus, :ram, :disk,
+           to: :template
+
+end

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -1,3 +1,30 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
 class InstancePresenter < DevicePresenter
   delegate :vcpus, :ram, :disk,
            to: :template

--- a/app/presenters/network_presenter.rb
+++ b/app/presenters/network_presenter.rb
@@ -1,0 +1,2 @@
+class NetworkPresenter < DevicePresenter
+end

--- a/app/presenters/network_presenter.rb
+++ b/app/presenters/network_presenter.rb
@@ -1,2 +1,29 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
 class NetworkPresenter < DevicePresenter
 end

--- a/app/presenters/volume_presenter.rb
+++ b/app/presenters/volume_presenter.rb
@@ -1,0 +1,2 @@
+class VolumePresenter < DevicePresenter
+end

--- a/app/presenters/volume_presenter.rb
+++ b/app/presenters/volume_presenter.rb
@@ -1,2 +1,29 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
 class VolumePresenter < DevicePresenter
 end

--- a/app/services/node_services/create.rb
+++ b/app/services/node_services/create.rb
@@ -74,6 +74,7 @@ module NodeServices
       raise UnsupportedError, "complex chassis are not supported" if @template.complex?
 
       Rails.logger.debug("Persisting template #{@template.id}")
+      Rails.logger.debug(@device_params)
       Chassis.transaction do
         create_object_graph
         @user.ability.authorize!(:update, @chassis.rack)

--- a/app/services/node_services/create.rb
+++ b/app/services/node_services/create.rb
@@ -74,7 +74,6 @@ module NodeServices
       raise UnsupportedError, "complex chassis are not supported" if @template.complex?
 
       Rails.logger.debug("Persisting template #{@template.id}")
-      Rails.logger.debug(@device_params)
       Chassis.transaction do
         create_object_graph
         @user.ability.authorize!(:update, @chassis.rack)

--- a/app/services/statistics_services/summary.rb
+++ b/app/services/statistics_services/summary.rb
@@ -48,7 +48,7 @@ module StatisticsServices
       end
 
       def servers_stats
-        servers = Device.joins(:template).where(details_type: "Device::ComputeDetails")
+        servers = Instance.joins(:template).all
         {
           active: servers.where(status: %w(ACTIVE IN_PROGRESS)).count,
           inactive: servers.where(status: %w(FAILED STOPPED SUSPENDED)).count,
@@ -59,19 +59,19 @@ module StatisticsServices
       end
 
       def volumes_stats
-        volumes = Device.where(details_type: "Device::VolumeDetails")
+        volumes = Volume.joins(:template).all
         {
           active: volumes.where(status: %w(ACTIVE IN_PROGRESS)).count,
-          inactive: volumes.where(status: %w(FAILED STOPPED SUSPENDED)).count,
+          inactive: volumes.where(status: %w(FAILED STOPPED AVAILABLE)).count,
           total_disk_space: "#{volumes.reduce(0) {|sum, volume| sum + (volume.details.size || 0)}}GB"
         }
       end
 
       def networks_stats
-        networks = Device.where(details_type: "Device::NetworkDetails")
+        networks = Network.joins(:template).all
         {
           active: networks.where(status: %w(ACTIVE IN_PROGRESS)).count,
-          inactive: networks.where(status: %w(FAILED STOPPED SUSPENDED)).count,
+          inactive: networks.where(status: %w(FAILED STOPPED)).count,
         }
       end
 

--- a/app/services/team_services/quota_stats.rb
+++ b/app/services/team_services/quota_stats.rb
@@ -46,15 +46,15 @@ module TeamServices
     private
 
     def servers
-      @team.devices.joins(:template).where(details_type: "Device::ComputeDetails")
+      @team.devices.joins(:template).where(type: "Instance")
     end
 
     def volumes
-      @team.devices.where(details_type: "Device::VolumeDetails")
+      @team.devices.where(type: "Volume")
     end
 
     def networks
-      @team.devices.where(details_type: "Device::NetworkDetails")
+      @team.devices.where(type: "Network")
     end
 
     def total_vcpus

--- a/app/views/api/v1/devices/show.rabl
+++ b/app/views/api/v1/devices/show.rabl
@@ -1,6 +1,6 @@
 object @device
 
-attributes :id, :name, :description, :metadata, :status, :cost, :location
+attributes :id, :name, :description, :metadata, :status, :cost, :location, :type
 
 child(:template, if: @include_full_template_details) do
   extends 'api/v1/templates/show'
@@ -8,9 +8,6 @@ end
 
 glue :details do |details|
   extends "api/v1/devices/details/#{details.class.name.split('::').last.underscore}"
-  node :type do |details|
-    details.class.name
-  end
 end
 
 attribute :template_id, unless: @include_full_template_details

--- a/app/views/api/v1/irv/racks/show.rabl
+++ b/app/views/api/v1/irv/racks/show.rabl
@@ -42,7 +42,7 @@ child(:chassis, root: 'Chassis') do |foo|
         name: chassis.device.name,
         buildStatus: chassis.device.status,
         cost: chassis.device.currency_cost,
-        type: chassis.device.details_type
+        type: chassis.device.type
       },
     }
   end

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -6,6 +6,7 @@
     definition_list "Details" do |dl|
       presenter_for(@device) do |device|
         dl.item "Name:", device.name
+        dl.item "Type", device.type
         dl.item "Description:", device.description
         dl.item "Height:", device.u_height
         dl.item "Location:", device.location
@@ -21,10 +22,12 @@
           sl.item "Description:", device.template_description
         end
 
-        dl.sublist "Resources:" do |sl|
-          sl.item "VCPUs:", device.vcpus
-          sl.item "RAM (MB)", device.ram
-          sl.item "Disk (GB)", device.disk
+        if device.respond_to?(:vcpus)
+          dl.sublist "Resources:" do |sl|
+            sl.item "VCPUs:", device.vcpus
+            sl.item "RAM (MB)", device.ram
+            sl.item "Disk (GB)", device.disk
+          end
         end
 
         if device.has_metadata?

--- a/app/views/interactive_rack_views/_configuration.json
+++ b/app/views/interactive_rack_views/_configuration.json
@@ -488,7 +488,7 @@
             {
               "caption" : "Destroy",
               "url"     : "internal::statusChangeRequest,destroy,devices,[[device_id]],[[device_name]]",
-              "availableToBuildStatuses": ["STOPPED", "FAILED"],
+              "availableToBuildStatuses": ["AVAILABLE", "FAILED"],
               "rbacAction" : "manage"
             },
             {

--- a/app/views/interactive_rack_views/_configuration.json
+++ b/app/views/interactive_rack_views/_configuration.json
@@ -447,12 +447,12 @@
               "url"     : "/devices/[[device_id]]",
               "rbacAction" : "view",
               "newTab":  true
+            },
+            {
+              "caption": "[[spacer]]"
             }
           ],
           "Device::ComputeDetails": [
-            {
-              "caption": "[[spacer]]"
-            },
             {
               "caption" : "Switch off",
               "url"     : "internal::statusChangeRequest,off,devices,[[device_id]],[[device_name]]",
@@ -481,6 +481,20 @@
               "caption" : "Destroy",
               "url"     : "internal::statusChangeRequest,destroy,devices,[[device_id]],[[device_name]]",
               "availableToBuildStatuses": ["STOPPED", "ACTIVE", "SUSPENDED", "FAILED"],
+              "rbacAction" : "manage"
+            }
+          ],
+          "Device::VolumeDetails": [
+            {
+              "caption" : "Destroy",
+              "url"     : "internal::statusChangeRequest,destroy,devices,[[device_id]],[[device_name]]",
+              "availableToBuildStatuses": ["STOPPED", "FAILED"],
+              "rbacAction" : "manage"
+            },
+            {
+              "caption" : "Detach",
+              "url"     : "internal::statusChangeRequest,detach,devices,[[device_id]],[[device_name]]",
+              "availableToBuildStatuses": ["ACTIVE"],
               "rbacAction" : "manage"
             }
           ]

--- a/app/views/interactive_rack_views/_configuration.json
+++ b/app/views/interactive_rack_views/_configuration.json
@@ -452,7 +452,7 @@
               "caption": "[[spacer]]"
             }
           ],
-          "Device::ComputeDetails": [
+          "Instance": [
             {
               "caption" : "Switch off",
               "url"     : "internal::statusChangeRequest,off,devices,[[device_id]],[[device_name]]",
@@ -484,7 +484,7 @@
               "rbacAction" : "manage"
             }
           ],
-          "Device::VolumeDetails": [
+          "Volume": [
             {
               "caption" : "Destroy",
               "url"     : "internal::statusChangeRequest,destroy,devices,[[device_id]],[[device_name]]",

--- a/app/views/interactive_rack_views/_configuration.json
+++ b/app/views/interactive_rack_views/_configuration.json
@@ -497,6 +497,14 @@
               "availableToBuildStatuses": ["ACTIVE"],
               "rbacAction" : "manage"
             }
+          ],
+          "Network": [
+            {
+              "caption" : "Destroy",
+              "url"     : "internal::statusChangeRequest,destroy,devices,[[device_id]],[[device_name]]",
+              "availableToBuildStatuses": ["ACTIVE", "FAILED", "STOPPED"],
+              "rbacAction" : "manage"
+            }
           ]
         },
         "common": []

--- a/db/migrate/20240507103025_add_type_to_devices.rb
+++ b/db/migrate/20240507103025_add_type_to_devices.rb
@@ -1,0 +1,19 @@
+class AddTypeToDevices < ActiveRecord::Migration[7.1]
+  class Device < ApplicationRecord
+  end
+
+  def up
+    add_column :devices, :type, :string
+
+    Device.where(details_type: "Device::ComputeDetails").update_all(type: "Instance")
+    Device.where(details_type: "Device::NetworkDetails").update_all(type: "Network")
+    Device.where(details_type: "Device::VolumeDetails").update_all(type: "Volume")
+
+    change_column_null :devices, :type, false
+    add_index :devices, :type
+  end
+
+  def down
+    remove_column :devices, :type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_19_145630) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_07_103025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -144,7 +144,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_19_145630) do
     t.uuid "base_chassis_id", null: false
     t.string "details_type"
     t.uuid "details_id"
+    t.string "type", null: false
     t.index ["base_chassis_id"], name: "index_devices_on_base_chassis_id"
+    t.index ["type"], name: "index_devices_on_type"
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/docs/api/examples/create-volume.sh
+++ b/docs/api/examples/create-volume.sh
@@ -40,6 +40,7 @@ BODY=$(jq --null-input \
     "template_id": $template_id,
     "device": {
         "name": $name,
+        "type": "Volume",
         "description": $description,
         "location": {
             "facing": $facing,

--- a/spec/channels/interactive_rack_view_channel_spec.rb
+++ b/spec/channels/interactive_rack_view_channel_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe InteractiveRackViewChannel, type: :channel do
     let!(:rack) { create(:rack, team: team, template: template) }
     let!(:team_role) { create(:team_role, team: team, user: user) }
     let(:device_template) { create(:template, :device_template) }
-    let!(:device) { create(:device, chassis: chassis) }
+    let!(:device) { create(:instance, chassis: chassis) }
     let(:chassis) { create(:chassis, location: location, template: device_template) }
     let(:location) { create(:location, rack: rack) }
 

--- a/spec/factories/device.rb
+++ b/spec/factories/device.rb
@@ -30,6 +30,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Device-#{n}" }
     metadata { {openstack_instance: "abc"} }
     status { 'IN_PROGRESS' }
+    type { "Instance" }
 
     association :chassis
     association :details, factory: :device_compute_details

--- a/spec/factories/device/instance.rb
+++ b/spec/factories/device/instance.rb
@@ -26,8 +26,8 @@
 #==============================================================================
 
 FactoryBot.define do
-  factory :device, class: "Device" do
-    sequence(:name) { |n| "Device-#{n}" }
+  factory :instance, class: "Instance" do
+    sequence(:name) { |n| "Instance-#{n}" }
     metadata { {openstack_instance: "abc"} }
     status { 'IN_PROGRESS' }
     type { "Instance" }

--- a/spec/factories/device/network.rb
+++ b/spec/factories/device/network.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :network, class: "Network" do
+    sequence(:name) { |n| "Network-#{n}" }
+    metadata { {openstack_instance: "abc"} }
+    status { 'IN_PROGRESS' }
+    type { "Network" }
+
+    association :chassis
+    association :details, factory: :device_network_details
+  end
+end

--- a/spec/factories/device/volume.rb
+++ b/spec/factories/device/volume.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :volume, class: "Volume" do
+    sequence(:name) { |n| "Volume-#{n}" }
+    metadata { {openstack_instance: "abc"} }
+    status { 'IN_PROGRESS' }
+    type { "Volume" }
+
+    association :chassis
+    association :details, factory: :device_volume_details
+  end
+end

--- a/spec/jobs/broadcast_rack_change_job_spec.rb
+++ b/spec/jobs/broadcast_rack_change_job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BroadcastRackChangeJob, type: :job do
   let(:template) { create(:template, :rack_template) }
   let(:device_template) { create(:template, :device_template) }
   let!(:rack) { create(:rack, team: team, template: template) }
-  let!(:device) { create(:device, chassis: chassis) }
+  let!(:device) { create(:instance, chassis: chassis) }
   let(:chassis) { create(:chassis, location: location, template: device_template) }
   let(:location) { create(:location, rack: rack) }
   subject { BroadcastRackChangeJob.perform_now(rack.id, team.id, action) }

--- a/spec/jobs/request_status_change_job_spec.rb
+++ b/spec/jobs/request_status_change_job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RequestStatusChangeJob, type: :job do
   let(:customer_user) { create(:user, :with_openstack_account) }
   let(:admin) { create(:user, :admin) }
   let(:user) { customer_user }
-  let(:device) { create(:device, chassis: chassis, status: "ACTIVE") }
+  let(:device) { create(:instance, chassis: chassis, status: "ACTIVE") }
   let(:chassis) { create(:chassis, location: location, template: device_template) }
   let(:location) { create(:location, rack: rack) }
   let(:rack) { create(:rack, template: rack_template, status: "ACTIVE") }

--- a/spec/models/device/network_details_spec.rb
+++ b/spec/models/device/network_details_spec.rb
@@ -32,33 +32,21 @@ RSpec.describe Device::NetworkDetails, type: :model do
   let!(:rack_template) { create(:template, :rack_template) }
   let!(:rack) { create(:rack, team: team, template: rack_template) }
   let(:location) { create(:location, rack: rack) }
-  let(:chassis) { create(:chassis, location: location, template: template) }
-
-  let(:device_template) { create(:template, :device_template) }
+  let(:chassis) { create(:chassis, location: location, template: network_template) }
   let(:network_template) { create(:template, :network_device_template) }
 
-  let(:device) { create(:device, chassis: chassis, details: described_class.new) }
+  let(:device) { create(:network, chassis: chassis, details: described_class.new) }
 
   subject { device.details }
 
   describe 'validations' do
-    context 'for a device using the network template' do
-      let(:template) { network_template }
-
+    context 'for a network device' do
       it { is_expected.to be_valid }
-    end
 
-    context 'for a device using the compute device template' do
-      let(:template) { device_template }
-
-      it { is_expected.not_to be_valid }
-      it { is_expected.to have_error :device, 'must use the `network` template if it has a Device::NetworkDetails' }
-
-      it 'also shows error on device' do
-        expect(device).not_to be_valid
-        expect(device).to have_error :details, 'is invalid'
+      it 'is invalid if device is not a network' do
+        device.update(type: "Instance")
+        expect(subject).to have_error(:device, "must be a Network")
       end
     end
-
   end
 end

--- a/spec/models/device/volume_details_spec.rb
+++ b/spec/models/device/volume_details_spec.rb
@@ -32,33 +32,21 @@ RSpec.describe Device::VolumeDetails, type: :model do
   let!(:rack_template) { create(:template, :rack_template) }
   let!(:rack) { create(:rack, team: team, template: rack_template) }
   let(:location) { create(:location, rack: rack) }
-  let(:chassis) { create(:chassis, location: location, template: template) }
-
-  let(:device_template) { create(:template, :device_template) }
+  let(:chassis) { create(:chassis, location: location, template: volume_template) }
   let(:volume_template) { create(:template, :volume_device_template) }
 
-  let(:device) { create(:device, chassis: chassis, details: described_class.new) }
+  let(:device) { create(:volume, chassis: chassis, details: described_class.new) }
 
   subject { device.details }
 
   describe 'validations' do
-    context 'for a device using the volume template' do
-      let(:template) { volume_template }
-
+    context 'for a volume device' do
       it { is_expected.to be_valid }
-    end
 
-    context 'for a device using the compute device template' do
-      let(:template) { device_template }
-
-      it { is_expected.not_to be_valid }
-      it { is_expected.to have_error :device, 'must use the `volume` template if it has a Device::VolumeDetails' }
-
-      it 'also shows error on device' do
-        expect(device).not_to be_valid
-        expect(device).to have_error :details, 'is invalid'
+      it 'is invalid if device is not a volume' do
+        device.update(type: "Instance")
+        expect(subject).to have_error(:device, "must be a Volume")
       end
     end
-
   end
 end

--- a/spec/models/hw_rack_spec.rb
+++ b/spec/models/hw_rack_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe HwRack, type: :model do
 
       context 'with device' do
         let(:device_template) { create(:template, :device_template) }
-        let!(:device) { create(:device, chassis: chassis) }
+        let!(:device) { create(:instance, chassis: chassis) }
         let(:chassis) { create(:chassis, location: location, template: device_template) }
         let(:location) { create(:location, rack: rack) }
 

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -27,10 +27,10 @@
 
 require 'rails_helper'
 
-RSpec.describe Device, type: :model do
+RSpec.describe Instance, type: :model do
   let!(:rack_template) { create(:template, :rack_template) }
   subject { device }
-  let(:device) { create(:device, chassis: chassis) }
+  let(:device) { create(:instance, chassis: chassis) }
   let(:chassis) { create(:chassis, location: location, template: device_template) }
   let(:location) { create(:location, rack: rack) }
   let!(:rack) { create(:rack, template: rack_template) }
@@ -43,7 +43,7 @@ RSpec.describe Device, type: :model do
         chassis: chassis,
         name: 'device-0',
         status: 'IN_PROGRESS',
-        cost: 99.99
+        cost: 99.99,
       )
       device.details = Device::ComputeDetails.new
       expect(device).to be_valid
@@ -75,7 +75,7 @@ RSpec.describe Device, type: :model do
     end
 
     it "must have a unique name within its rack" do
-      new_device = build(:device, chassis: chassis, name: subject.name)
+      new_device = build(:instance, chassis: chassis, name: subject.name)
 
       expect(new_device.name).to eq device.name
       expect(new_device).to have_error(:name, :taken)
@@ -85,7 +85,7 @@ RSpec.describe Device, type: :model do
       new_rack = create(:rack, template: rack_template)
       new_location = create(:location, rack: new_rack)
       new_chassis = create(:chassis, location: new_location, template: device_template)
-      new_device = build(:device, chassis: new_chassis, name: subject.name)
+      new_device = build(:instance, chassis: new_chassis, name: subject.name)
 
       expect(new_device.name).to eq device.name
       expect(new_device).not_to have_error(:name)
@@ -98,7 +98,7 @@ RSpec.describe Device, type: :model do
 
     it "is not vaild with an invalid status" do
       subject.status = "SNAFU"
-      expect(subject).to have_error(:status, :inclusion)
+      expect(subject).to have_error(:status, "must be one of IN_PROGRESS, FAILED, ACTIVE, STOPPED or SUSPENDED")
     end
 
     it "is not valid with a negative cost" do
@@ -113,7 +113,7 @@ RSpec.describe Device, type: :model do
 
     it "is not valid with a details model that is an invalid class" do
       subject.details = location
-      expect(subject).to have_error(:details_type, "Must be a valid subtype of Device::Details")
+      expect(subject).to have_error(:details_type, "must have compute details")
       # This is a secondary error, but until we add a second Device::Details
       # subclass, this test is the only way we can assert it's returned:
       expect(subject).to have_error(:details_type, "Cannot be changed once a device has been created")
@@ -151,7 +151,7 @@ RSpec.describe Device, type: :model do
 
     context 'updated' do
       let(:action) { "modified" }
-      let!(:device) { create(:device, chassis: chassis) }
+      let!(:device) { create(:instance, chassis: chassis) }
       subject do
         device.name = "new-name"
         device.save!
@@ -162,7 +162,7 @@ RSpec.describe Device, type: :model do
 
     context 'deleted' do
       let(:action) { "modified" }
-      let!(:device) { create(:device, chassis: chassis) }
+      let!(:device) { create(:instance, chassis: chassis) }
       subject { device.destroy! }
 
       include_examples 'rack details'

--- a/spec/models/network_spec.rb
+++ b/spec/models/network_spec.rb
@@ -28,11 +28,11 @@
 require 'rails_helper'
 require_relative '../support/shared_examples/devices'
 
-RSpec.describe Instance, type: :model do
-  let(:device_type) { :instance }
-  let(:template_type) { :device_template }
-  let(:details_class) { Device::ComputeDetails }
-  let(:valid_statuses) { %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED) }
+RSpec.describe Network, type: :model do
+  let(:device_type) { :network }
+  let(:template_type) { :network_device_template }
+  let(:details_class) { Device::NetworkDetails }
+  let(:valid_statuses) { %w(IN_PROGRESS FAILED ACTIVE STOPPED) }
 
   include_examples 'device models'
 end

--- a/spec/models/volume_spec.rb
+++ b/spec/models/volume_spec.rb
@@ -28,11 +28,11 @@
 require 'rails_helper'
 require_relative '../support/shared_examples/devices'
 
-RSpec.describe Instance, type: :model do
-  let(:device_type) { :instance }
-  let(:template_type) { :device_template }
-  let(:details_class) { Device::ComputeDetails }
-  let(:valid_statuses) { %w(IN_PROGRESS FAILED ACTIVE STOPPED SUSPENDED) }
+RSpec.describe Volume, type: :model do
+  let(:device_type) { :volume }
+  let(:template_type) { :volume_device_template }
+  let(:details_class) { Device::VolumeDetails }
+  let(:valid_statuses) { %w(IN_PROGRESS FAILED ACTIVE AVAILABLE) }
 
   include_examples 'device models'
 end

--- a/spec/requests/api/v1/devices_controller_spec.rb
+++ b/spec/requests/api/v1/devices_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
       end
 
       context "when there is one device" do
-        let!(:device) { create(:device, chassis: chassis, metadata: {foo: :bar}) }
+        let!(:device) { create(:instance, chassis: chassis, metadata: {foo: :bar}) }
         let(:chassis) { create(:chassis, template: device_template, location: location) }
         let(:location) { create(:location, rack: rack) }
 
@@ -95,8 +95,8 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
         let!(:devices) {
           dt = device_template
           [
-            create(:device, metadata: {foo: "one"}, chassis: create(:chassis, template: dt, location: create(:location, rack: rack, start_u: 1))),
-            create(:device, metadata: {foo: "two"}, chassis: create(:chassis, template: dt, location: create(:location, rack: rack, start_u: 2))),
+            create(:instance, metadata: {foo: "one"}, chassis: create(:chassis, template: dt, location: create(:location, rack: rack, start_u: 1))),
+            create(:instance, metadata: {foo: "two"}, chassis: create(:chassis, template: dt, location: create(:location, rack: rack, start_u: 2))),
           ]
         }
 
@@ -121,7 +121,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
 
   describe "GET :show" do
     let(:url_under_test) { urls.api_v1_device_path(device) }
-    let!(:device) { create(:device, chassis: chassis) }
+    let!(:device) { create(:instance, chassis: chassis) }
     let(:chassis) { create(:chassis, template: device_template, location: location) }
     let(:location) { create(:location, rack: rack) }
     let(:full_template_details) { true }
@@ -157,7 +157,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
 
   describe "PATCH :update" do
     let(:url_under_test) { urls.api_v1_device_path(device) }
-    let!(:device) { create(:device, chassis: chassis) }
+    let!(:device) { create(:instance, chassis: chassis) }
     let(:chassis) { create(:chassis, template: device_template, location: location) }
     let(:location) { create(:location, rack: rack) }
     let(:full_template_details) { true }
@@ -371,7 +371,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
       context 'with a network device' do
         let(:device_template) { create(:template, :network_device_template) }
         let(:details) { create(:device_network_details) }
-        let!(:device) { create(:device, chassis: chassis, details: details) }
+        let!(:device) { create(:network, chassis: chassis, details: details) }
 
         context "with valid parameters" do
           let(:attributes) {
@@ -420,7 +420,7 @@ RSpec.describe "Api::V1::DevicesControllers", type: :request do
       context 'with a volume device' do
         let(:device_template) { create(:template, :volume_device_template) }
         let(:details) { create(:device_volume_details) }
-        let!(:device) { create(:device, chassis: chassis, details: details) }
+        let!(:device) { create(:volume, chassis: chassis, details: details) }
 
         context "with valid parameters" do
           let(:attributes) {

--- a/spec/requests/api/v1/metrics_controller_spec.rb
+++ b/spec/requests/api/v1/metrics_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Api::V1::MetricsController", type: :request do
   let(:chassis) { create(:chassis, template: device_template, location: location) }
   let(:location) { create(:location, rack: rack) }
   let(:device_template) { create(:template, :device_template) }
-  let(:device) { create(:device, chassis: chassis, metadata: {foo: :bar}) }
+  let(:device) { create(:instance, chassis: chassis, metadata: {foo: :bar}) }
   let(:rack_owner) { create(:user) }
 
   let(:headers) { {} }

--- a/spec/requests/api/v1/nodes_controller_spec.rb
+++ b/spec/requests/api/v1/nodes_controller_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           template_id: device_template.id,
           device: {
             name: "device-1",
+            type: "Instance",
             description: "device-1 description",
             location: {
               rack_id: rack.id,
@@ -75,6 +76,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           template_id: device_template.id,
           device: {
             name: "device-1",
+            type: "Instance",
             description: "device-1 description",
             location: {
               rack_id: rack.id,
@@ -98,6 +100,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           device: {
             name: "not a valid name",
             status: 'not a valid status',
+            type: "Instance",
             details: {
               type: 'herring'
             }
@@ -136,6 +139,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           ).stringify_keys
 
           expect(parsed_device["name"]).to eq valid_attributes[:device][:name]
+          expect(parsed_device["type"]).to eq valid_attributes[:device][:type]
           expect(parsed_device["description"]).to eq valid_attributes[:device][:description]
           expect(parsed_device["location"]).to eq expected_location
           expect(parsed_device["metadata"]).to eq valid_attributes[:device][:metadata]
@@ -185,6 +189,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           ).stringify_keys
 
           expect(parsed_device["name"]).to eq legacy_valid_attributes[:device][:name]
+          expect(parsed_device["type"]).to eq legacy_valid_attributes[:device][:type]
           expect(parsed_device["description"]).to eq legacy_valid_attributes[:device][:description]
           expect(parsed_device["location"]).to eq expected_location
           expect(parsed_device["metadata"]).to eq legacy_valid_attributes[:device][:metadata]
@@ -227,6 +232,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
             template_id: device_template.id,
             device: {
               name: "net-1",
+              type: "Network",
               description: "net-1 description",
               location: {
                 rack_id: rack.id,
@@ -275,6 +281,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           ).stringify_keys
 
           expect(parsed_device["name"]).to eq valid_attributes[:device][:name]
+          expect(parsed_device["type"]).to eq valid_attributes[:device][:type]
           expect(parsed_device["description"]).to eq valid_attributes[:device][:description]
           expect(parsed_device["location"]).to eq expected_location
           expect(parsed_device["metadata"]).to eq valid_attributes[:device][:metadata]
@@ -295,6 +302,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
             template_id: device_template.id,
             device: {
               name: "vol-1",
+              type: "Volume",
               description: "vol-1 description",
               location: {
                 rack_id: rack.id,
@@ -336,6 +344,7 @@ RSpec.describe "Api::V1::NodesControllers", type: :request do
           parsed_device = JSON.parse(response.body)
 
           expect(parsed_device["name"]).to eq valid_attributes[:device][:name]
+          expect(parsed_device["type"]).to eq valid_attributes[:device][:type]
           expect(parsed_device["description"]).to eq valid_attributes[:device][:description]
           expect(parsed_device["metadata"]).to eq valid_attributes[:device][:metadata]
           expect(parsed_device["status"]).to eq valid_attributes[:device][:status]

--- a/spec/services/statistics_services/summary_spec.rb
+++ b/spec/services/statistics_services/summary_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe StatisticsServices::Summary, type: :service do
     let!(:rack_template) { create(:template, :rack_template) }
     let(:template) { create(:template, :device_template, vcpus: 2, ram: 4096, disk: 10) }
     let(:chassis) { create(:chassis, template: template) }
-    let!(:server) { create(:device, status: "STOPPED", chassis: chassis) }
-    let!(:another_server) { create(:device, status: "FAILED", chassis: chassis) }
-    let!(:further_server) { create(:device, status: "ACTIVE", chassis: chassis) }
+    let!(:server) { create(:instance, status: "STOPPED", chassis: chassis) }
+    let!(:another_server) { create(:instance, status: "FAILED", chassis: chassis) }
+    let!(:further_server) { create(:instance, status: "ACTIVE", chassis: chassis) }
 
     it 'includes counts, vcpu, ram and disk usage' do
       expected = {
@@ -86,9 +86,9 @@ RSpec.describe StatisticsServices::Summary, type: :service do
     let!(:rack_template) { create(:template, :rack_template) }
     let(:template) { create(:template, :volume_device_template) }
     let(:chassis) { create(:chassis, template: template) }
-    let!(:volume) { create(:device, details: Device::VolumeDetails.new(size: 100), status: "STOPPED", chassis: chassis) }
-    let!(:another_volume) { create(:device, details: Device::VolumeDetails.new(size: 200), status: "FAILED", chassis: chassis) }
-    let!(:further_volume) { create(:device, details: Device::VolumeDetails.new(size: 10), status: "ACTIVE", chassis: chassis) }
+    let!(:volume) { create(:volume, details: Device::VolumeDetails.new(size: 100), status: "AVAILABLE", chassis: chassis) }
+    let!(:another_volume) { create(:volume, details: Device::VolumeDetails.new(size: 200), status: "FAILED", chassis: chassis) }
+    let!(:further_volume) { create(:volume, details: Device::VolumeDetails.new(size: 10), status: "ACTIVE", chassis: chassis) }
 
     it 'includes counts and disk usage' do
       expected = {
@@ -104,9 +104,9 @@ RSpec.describe StatisticsServices::Summary, type: :service do
     let!(:rack_template) { create(:template, :rack_template) }
     let(:template) { create(:template, :network_device_template) }
     let(:chassis) { create(:chassis, template: template) }
-    let!(:network) { create(:device, details: Device::NetworkDetails.new, status: "STOPPED", chassis: chassis) }
-    let!(:another_network) { create(:device, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
-    let!(:further_network) { create(:device, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
+    let!(:network) { create(:network, details: Device::NetworkDetails.new, status: "STOPPED", chassis: chassis) }
+    let!(:another_network) { create(:network, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
+    let!(:further_network) { create(:network, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
 
     it 'includes network counts' do
       expect(subject[:networks]).to eq({active: 2, inactive: 1})

--- a/spec/services/team_services/quota_stats_spec.rb
+++ b/spec/services/team_services/quota_stats_spec.rb
@@ -68,10 +68,10 @@ RSpec.describe TeamServices::QuotaStats, type: :service do
 
   context 'has servers' do
     let(:template) { create(:template, :device_template, vcpus: 2, ram: 4096, disk: 10) }
-    let!(:server) { create(:device, status: "STOPPED", chassis: chassis) }
-    let!(:another_server) { create(:device, status: "FAILED", chassis: chassis) }
-    let!(:further_server) { create(:device, status: "ACTIVE", chassis: chassis) }
-    let!(:other_team_server) { create(:device, chassis: other_team_chassis) }
+    let!(:server) { create(:instance, status: "STOPPED", chassis: chassis) }
+    let!(:another_server) { create(:instance, status: "FAILED", chassis: chassis) }
+    let!(:further_server) { create(:instance, status: "ACTIVE", chassis: chassis) }
+    let!(:other_team_server) { create(:instance, chassis: other_team_chassis) }
 
     it 'includes counts, vcpu, ram and disk usage' do
       expected = {
@@ -87,9 +87,9 @@ RSpec.describe TeamServices::QuotaStats, type: :service do
 
     context 'and volume' do
       let(:another_location) { create(:location, rack: rack) }
-      let(:another_chassis) { create(:chassis, template: template, location: location) }
+      let(:another_chassis) { create(:chassis, template: vol_template, location: location) }
       let(:vol_template) { create(:template, :volume_device_template) }
-      let!(:volume) { create(:device, details: Device::VolumeDetails.new(size: 100), status: "STOPPED", chassis: another_chassis) }
+      let!(:volume) { create(:volume, details: Device::VolumeDetails.new(size: 100), status: "AVAILABLE", chassis: another_chassis) }
 
       it 'combines server and volume disk space' do
         expected = {
@@ -107,10 +107,10 @@ RSpec.describe TeamServices::QuotaStats, type: :service do
 
   context 'has volumes' do
     let(:template) { create(:template, :volume_device_template) }
-    let!(:volume) { create(:device, details: Device::VolumeDetails.new(size: 100), status: "STOPPED", chassis: chassis) }
-    let!(:another_volume) { create(:device, details: Device::VolumeDetails.new(size: 200), status: "FAILED", chassis: chassis) }
-    let!(:further_volume) { create(:device, details: Device::VolumeDetails.new(size: 10), status: "ACTIVE", chassis: chassis) }
-    let!(:other_team_volume) { create(:device, details: Device::VolumeDetails.new(size: 10), chassis: other_team_chassis) }
+    let!(:volume) { create(:volume, details: Device::VolumeDetails.new(size: 100), status: "AVAILABLE", chassis: chassis) }
+    let!(:another_volume) { create(:volume, details: Device::VolumeDetails.new(size: 200), status: "FAILED", chassis: chassis) }
+    let!(:further_volume) { create(:volume, details: Device::VolumeDetails.new(size: 10), status: "ACTIVE", chassis: chassis) }
+    let!(:other_team_volume) { create(:volume, details: Device::VolumeDetails.new(size: 10), chassis: other_team_chassis) }
 
     it 'includes counts and disk usage' do
       expected = {
@@ -128,10 +128,10 @@ RSpec.describe TeamServices::QuotaStats, type: :service do
   context 'has networks' do
     let!(:rack_template) { create(:template, :rack_template) }
     let(:template) { create(:template, :network_device_template) }
-    let!(:network) { create(:device, details: Device::NetworkDetails.new, status: "STOPPED", chassis: chassis) }
-    let!(:another_network) { create(:device, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
-    let!(:further_network) { create(:device, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
-    let!(:other_team_network) { create(:device, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: other_team_chassis) }
+    let!(:network) { create(:network, details: Device::NetworkDetails.new, status: "STOPPED", chassis: chassis) }
+    let!(:another_network) { create(:network, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
+    let!(:further_network) { create(:network, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: chassis) }
+    let!(:other_team_network) { create(:network, details: Device::NetworkDetails.new, status: "ACTIVE", chassis: other_team_chassis) }
 
     it 'includes network count' do
       expected = {

--- a/spec/support/shared_examples/devices.rb
+++ b/spec/support/shared_examples/devices.rb
@@ -73,6 +73,11 @@ RSpec.shared_examples "device models" do
       expect(subject).to have_error(:chassis, :blank)
     end
 
+    it "is not valid without appropriate template" do
+      subject.template.tag = "wrong"
+      expect(subject).to have_error(:template, "must use #{device_type[0] == "i" ? "an" : "the"} #{device_type} template")
+    end
+
     it "must have a unique name within its rack" do
       new_device = build(:instance, chassis: chassis, name: subject.name)
 
@@ -150,7 +155,7 @@ RSpec.shared_examples "device models" do
 
     context 'updated' do
       let(:action) { "modified" }
-      let!(:device) { create(:instance, chassis: chassis) }
+      let!(:device) { create(device_type, chassis: chassis) }
       subject do
         device.name = "new-name"
         device.save!
@@ -161,7 +166,7 @@ RSpec.shared_examples "device models" do
 
     context 'deleted' do
       let(:action) { "modified" }
-      let!(:device) { create(:instance, chassis: chassis) }
+      let!(:device) { create(device_type, chassis: chassis) }
       subject { device.destroy! }
 
       include_examples 'rack details'

--- a/spec/support/shared_examples/devices.rb
+++ b/spec/support/shared_examples/devices.rb
@@ -1,0 +1,170 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Concertim Visualisation App.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Concertim Visualisation App is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Concertim Visualisation App. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Concertim Visualisation App, please visit:
+# https://github.com/openflighthpc/concertim-ct-visualisation-app
+#==============================================================================
+
+# Requires definition of device_type, template_type, details_class and valid_statuses
+RSpec.shared_examples "device models" do
+  let!(:rack_template) { create(:template, :rack_template) }
+  subject { device }
+  let(:device) { create(device_type, chassis: chassis) }
+  let(:chassis) { create(:chassis, location: location, template: device_template) }
+  let(:location) { create(:location, rack: rack) }
+  let!(:rack) { create(:rack, template: rack_template) }
+  let(:user) { create(:user, :as_team_member, team: rack.team) }
+  let(:device_template) { create(:template, template_type) }
+
+  describe 'validations' do
+    it "is valid with valid attributes" do
+      device = described_class.new(
+        chassis: chassis,
+        name: 'device-0',
+        status: 'IN_PROGRESS',
+        cost: 99.99,
+        )
+      device.details = details_class.new
+      expect(device).to be_valid
+    end
+
+    it "is not valid without a name" do
+      subject.name = nil
+      expect(subject).to have_error(:name, :blank)
+    end
+
+    it "is not valid with badly formatted name" do
+      subject.name = "not a valid name"
+      expect(subject).to have_error(:name, :invalid)
+    end
+
+    it "is not valid with nil metadata" do
+      subject.metadata = nil
+      expect(subject).to have_error(:metadata, "Must be an object")
+    end
+
+    it "is valid with blank metadata" do
+      subject.metadata = {}
+      expect(subject).to be_valid
+    end
+
+    it "is not valid without a chassis" do
+      subject.chassis = nil
+      expect(subject).to have_error(:chassis, :blank)
+    end
+
+    it "must have a unique name within its rack" do
+      new_device = build(:instance, chassis: chassis, name: subject.name)
+
+      expect(new_device.name).to eq device.name
+      expect(new_device).to have_error(:name, :taken)
+    end
+
+    it "can duplicate names for devices in other racks" do
+      new_rack = create(:rack, template: rack_template)
+      new_location = create(:location, rack: new_rack)
+      new_chassis = create(:chassis, location: new_location, template: device_template)
+      new_device = build(:instance, chassis: new_chassis, name: subject.name)
+
+      expect(new_device.name).to eq device.name
+      expect(new_device).not_to have_error(:name)
+    end
+
+    it "is not vaild without a status" do
+      subject.status = nil
+      expect(subject).to have_error(:status, :blank)
+    end
+
+    it "is not vaild with an invalid status" do
+      subject.status = "SNAFU"
+      expect(subject).to have_error(:status, "must be one of #{valid_statuses.to_sentence(last_word_connector: ' or ')}")
+    end
+
+    it "is not valid with a negative cost" do
+      subject.cost = -99
+      expect(subject).to have_error(:cost, :greater_than_or_equal_to)
+    end
+
+    it "is not valid without a details model" do
+      subject.details = nil
+      expect(subject).to have_error(:details, :blank)
+    end
+
+    it "is not valid with a details model that is an invalid class" do
+      subject.details = location
+      expect(subject).to have_error(:details_type, "must have #{details_class.name.match(/::(\w+)Details/)[1].downcase} details")
+      # This is a secondary error, but until we add a second Device::Details
+      # subclass, this test is the only way we can assert it's returned:
+      expect(subject).to have_error(:details_type, "Cannot be changed once a device has been created")
+    end
+  end
+
+  describe "broadcast changes" do
+    shared_examples 'rack details' do
+      it 'broadcasts rack details' do
+        expect { subject }.to have_broadcasted_to(user).from_channel(InteractiveRackViewChannel).with { |data|
+          expect(data["action"]).to eq action
+          rack_data = data["rack"]
+          expect(rack_data.present?).to be true
+          expect(rack_data["owner"]["id"]).to eq rack.team.id.to_s
+          expect(rack_data["template"]["name"]).to eq rack.template.name
+          expect(rack_data["id"]).to eq rack.id.to_s
+          expect(rack_data["name"]).to eq rack.name
+          expect(rack_data["cost"]).to eq "$0.00"
+          if rack.reload.devices.exists?
+            expect(rack_data["Chassis"]["Slots"]["Machine"]["id"]).to eq device.id.to_s
+            expect(rack_data["Chassis"]["Slots"]["Machine"]["name"]).to eq device.name
+          else
+            expect(rack_data["Chassis"]["Slots"]).to eq nil
+          end
+        }
+      end
+    end
+
+    context 'created' do
+      let(:action) { "modified" }
+      subject { device }
+
+      include_examples 'rack details'
+    end
+
+    context 'updated' do
+      let(:action) { "modified" }
+      let!(:device) { create(:instance, chassis: chassis) }
+      subject do
+        device.name = "new-name"
+        device.save!
+      end
+
+      include_examples 'rack details'
+    end
+
+    context 'deleted' do
+      let(:action) { "modified" }
+      let!(:device) { create(:instance, chassis: chassis) }
+      subject { device.destroy! }
+
+      include_examples 'rack details'
+    end
+  end
+end


### PR DESCRIPTION
Related to #202 and dependent upon https://github.com/openflighthpc/concertim-openstack-service/tree/enh/device-deletion

- On the interactive rack view, adds the option to detach a volume from its instance
- Once detached, a volume is now assigned a new status of 'Available'. Available volumes now have the option to be deleted.
- This is required as a volume cannot be deleted whilst attached to an instance (even when using force delete)

- On the interactive rack view, also adds the option to destroy a network

- tests updated and added

Although deleting these devices should be a rare occurrence during the operation of a cluster, this should significantly help in situations (seen frequently during testing) where deleting a rack fails due to being unable to delete a device. This also sets up logic for more easily adding further actions for volumes and networks (and any other future device types)

**Implementation detail**
- Devices are now divided into subclasses `Instance`, `Volume` and `Network`, as they now have differing behaviour, such as different possible statuses and actions, and there may be further differences in the future
- this is some improvement on the previous approach of checking the device's Details class name to determine what kind of device they are
- this may require further thought if/when more device types are added