### PR TITLE
Remove detach volume option

### DIFF
--- a/app/javascript/canvas/irv/view/RackSpace.js
+++ b/app/javascript/canvas/irv/view/RackSpace.js
@@ -1605,15 +1605,9 @@ class RackSpace {
       case 'focusOn':
         return this.focusOn(params[1], params[2]);
       case 'statusChangeRequest':
-        let act = false;
-        if (!['destroy', 'detach'].includes(params[1])) {
-          act = true;
-        } else if (params[1] === 'destroy' && confirm(`Are you sure you want to destroy ${params[4]}? This cannot be undone and may prevent the cluster performing correctly.`)) {
-          act = true;
-        } else if (params[1] === 'detach' && confirm(`Are you sure you want to detach ${params[4]}? This may impact operation of its associated instance(s).`)) {
-          act = true;
+        if (params[1] !== 'destroy' || confirm(`Are you sure you want to destroy ${params[4]}? This cannot be undone.`)) {
+          return this.requestStatusChange(params[1], params[2], params[3], params[4]);
         }
-        if (act) return this.requestStatusChange(params[1], params[2], params[3], params[4]);
       case 'reset':
         return Events.dispatchEvent(this.rackEl, 'rackSpaceReset');
       case 'clearDeselected':

--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -41,7 +41,7 @@ class Volume < Device
     {
       "IN_PROGRESS" => [],
       "FAILED" => %w(destroy),
-      "ACTIVE" => %w(detach),
+      "ACTIVE" => [],
       "AVAILABLE" => %w(destroy)
     }
   end

--- a/app/views/interactive_rack_views/_configuration.json
+++ b/app/views/interactive_rack_views/_configuration.json
@@ -490,12 +490,6 @@
               "url"     : "internal::statusChangeRequest,destroy,devices,[[device_id]],[[device_name]]",
               "availableToBuildStatuses": ["AVAILABLE", "FAILED"],
               "rbacAction" : "manage"
-            },
-            {
-              "caption" : "Detach",
-              "url"     : "internal::statusChangeRequest,detach,devices,[[device_id]],[[device_name]]",
-              "availableToBuildStatuses": ["ACTIVE"],
-              "rbacAction" : "manage"
             }
           ],
           "Network": [


### PR DESCRIPTION
Removes the option to detach volumes, as in some environments this is forbidden, and due to the potential for it to disrupt operation of associated instances.

Volumes can still be destroyed, but this requires their instances to have already been destroyed (or detached manually, outside of concertim).